### PR TITLE
WASM extended niimathx() calculates robust range

### DIFF
--- a/src/bwlabel.c
+++ b/src/bwlabel.c
@@ -39,7 +39,7 @@
  ***************************************************************/
 
 void fill_tratab(uint32_t  *tt,     /* Translation table */
-                 uint32_t  ttn,     /* Size of translation table */
+                 /*uint32_t  ttn,*/     /* Size of translation table */
                  uint32_t  *nabo,   /* Set of neighbours */
                  uint32_t  nr_set)  /* Number of neighbours in nabo */
 {
@@ -83,8 +83,8 @@ uint32_t check_previous_slice(uint32_t  *il,     /* Initial labelling map */
                                   uint32_t  sl,      /* slice */
                                   size_t        dim[3],  /* dimensions of il */
                                   uint32_t  conn,    /* Connectivity criterion */
-                                  uint32_t  *tt,     /* Translation table */
-                                  uint32_t  ttn)     /* Size of translation table */
+                                  uint32_t  *tt)     /* Translation table */
+//                                  uint32_t  ttn)     /* Size of translation table */
 {
    uint32_t l=0;
    uint32_t nabo[9];
@@ -113,7 +113,7 @@ uint32_t check_previous_slice(uint32_t  *il,     /* Initial labelling map */
 
    if (nr_set) 
    {
-      fill_tratab(tt,ttn,nabo,nr_set);
+      fill_tratab(tt,/*ttn,*/nabo,nr_set);
       return(nabo[0]);
    }
    else {return(0);}
@@ -164,7 +164,7 @@ uint32_t do_initial_labelling(uint8_t        *bw,   /* Binary map */
             nr_set = 0;
             if (bw[idx(r,c,sl,dim)])
             {
-               nabo[0] = check_previous_slice(il,r,c,sl,dim,conn,*tt,ttn);
+               nabo[0] = check_previous_slice(il,r,c,sl,dim,conn,*tt /*,ttn*/);
                if (nabo[0]) {nr_set += 1;}
                /*
                   For six(surface)-connectivity
@@ -198,7 +198,7 @@ uint32_t do_initial_labelling(uint8_t        *bw,   /* Binary map */
                if (nr_set)
                {
                   il[idx(r,c,sl,dim)] = nabo[0];
-                  fill_tratab(*tt,ttn,nabo,nr_set);
+                  fill_tratab(*tt,/*ttn,*/nabo,nr_set);
                }
                else
                {
@@ -298,6 +298,10 @@ int bwlabel(nifti_image *nim, int conn) {
   uint32_t  *tt = NULL;
   uint32_t ttn = do_initial_labelling(bw,dim,conn,il,&tt);
   double nl = translate_labels(il,dim,tt,ttn,l);
+  nim->cal_min = 0;
+  nim->cal_max = nl;
+  nim->scl_inter = 0.0;
+  nim->scl_slope = 1.0;
   _mm_free(il);
   _mm_free(tt);
   if (nim->datatype == DT_FLOAT32) {

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -1692,10 +1692,9 @@ void symeig_double( int n , double *a , double *e ) {
 /* Author: Daniel Glen, 15 Nov 2004 */
 //https://github.com/afni/afni/blob/b6a9f7a21c1f3231ff09efbd861f8975ad48e525/src/3dDTeig.c
 //  Components developed at the US National Institutes of Health (after 15 Jan 2001) are not copyrighted.
-void EIG_tsfunc( double tzero, double tdelta ,
+void EIG_tsfunc(
                           int npts, float ts[],
-                          double ts_mean, double ts_slope,
-                          void * ud, int nbriks, float * val, int isUpperTriangle )
+                          float * val, int isUpperTriangle )
 {
   #define SMALLNUMBER 1E-4
   int i,j;

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -5,10 +5,9 @@
 extern "C" {
 #endif
 
-void EIG_tsfunc( double tzero, double tdelta ,
+void EIG_tsfunc(
                           int npts, float ts[],
-                          double ts_mean, double ts_slope,
-                          void * ud, int nbriks, float * val, int isUpperTriangle );
+                          float * val, int isUpperTriangle );
 
 #ifdef  __cplusplus
 }


### PR DESCRIPTION
 - niimath functions change voxel intensity. The new function WASM function `niimathx()` extends `niimath()` by re-calculating the robust range. This should be faster than re-calculating the robust range in JavaScript. This function also uses the NIfTI header scl_slope and scl_inter to appropriately handle integer values.
 - Code cleanup: Removes unused variables. 
