### PR TITLE
cmake/make : fix git protocol for ZLIB dependency

### DIFF
--- a/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
+++ b/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
@@ -1,7 +1,7 @@
 set(CLOUDFLARE_BRANCH gcc.amd64) # Cloudflare zlib branch
 
 ExternalProject_Add(zlib
-    GIT_REPOSITORY "${git_protocol}://github.com/ningfei/zlib.git"
+    GIT_REPOSITORY "${git_protocol}ningfei/zlib.git"
     GIT_TAG "${CLOUDFLARE_BRANCH}"
     SOURCE_DIR cloudflare-zlib
     BINARY_DIR cloudflare-zlib-build

--- a/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
+++ b/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
@@ -1,7 +1,7 @@
 set(CLOUDFLARE_BRANCH gcc.amd64) # Cloudflare zlib branch
 
 ExternalProject_Add(zlib
-    GIT_REPOSITORY "${git_protocol}ningfei/zlib.git"
+    GIT_REPOSITORY "${git_protocol}github.com/ningfei/zlib.git"
     GIT_TAG "${CLOUDFLARE_BRANCH}"
     SOURCE_DIR cloudflare-zlib
     BINARY_DIR cloudflare-zlib-build

--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -7,9 +7,9 @@ endif()
 # Use git protocol or not
 option(USE_GIT_PROTOCOL "If behind a firewall turn this off to use https instead." OFF)
 if(USE_GIT_PROTOCOL)
-    set(git_protocol "git@github.com:")
+    set(git_protocol "ssh://git@")
 else()
-    set(git_protocol "https://github.com/")
+    set(git_protocol "https://")
 endif()
 
 #emulate fslmaths behavior, add pigz support

--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -5,11 +5,11 @@ if(NOT GIT_FOUND)
 endif()
 
 # Use git protocol or not
-option(USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
+option(USE_GIT_PROTOCOL "If behind a firewall turn this off to use https instead." OFF)
 if(USE_GIT_PROTOCOL)
-    set(git_protocol "git")
+    set(git_protocol "git@github.com:")
 else()
-    set(git_protocol "https")
+    set(git_protocol "https://github.com/")
 endif()
 
 #emulate fslmaths behavior, add pigz support


### PR DESCRIPTION
`cmake` default option is to use `git` protocol. However, the prepared command line to clone the ZLIB dependency repo does not have the correct syntax : 
https://github.com/rordenlab/niimath/blob/b584afdb25ff0f10c69e8a48c57189eb91704276/SuperBuild/External-CLOUDFLARE-ZLIB.cmake#L4
`git://github.com/ningfei/zlib.git`
instead of
`git@github.com:ningfei/zlib.git`
In my case, the bad syntax creates a "silent error" : `make` tries to clone 3 times the repo, but fails. The 3 attempts take a lot of time because of a long timeout.

This PR is a proposition to fix this problem.

Also, I propose to change the default protocol to `https` because it might fit more use cases. As mentioned in the Makefile, firewall can block `git` protocol, while `https` is more accepted. However this a subject we can debate.