### PR TITLE
Feature/add support mesh inputs

### DIFF
--- a/js/index.html
+++ b/js/index.html
@@ -49,24 +49,26 @@
         const t0 = performance.now();
 
         // test the -mesh command and mesh output
-        const outName = 'out.mz3';
-        const outFile = await niimath.image(selectedFile)
-        .mesh({
-          i: 'm', // 'm' for medium
-          b: 1, // fill bubbles
-          v: 0 // not verbose
-        })
-        .run(outName)
-        const t1 = performance.now();
-        console.log("niimath wasm took " + (t1 - t0) + " milliseconds.")
-
-        // test with a volume output
-        // const outName = 'out.nii.gz';
+        // const outName = 'out.mz3';
         // const outFile = await niimath.image(selectedFile)
-        // .sobel()
+        // .mesh({
+        //   i: 'm', // 'm' for medium
+        //   b: 1, // fill bubbles
+        //   v: 0 // not verbose
+        // })
         // .run(outName)
         // const t1 = performance.now();
         // console.log("niimath wasm took " + (t1 - t0) + " milliseconds.")
+
+        // test with a volume output
+        const outName = 'out.nii.gz';
+        niimath.setOutputDataType('input')
+        const outFile = await niimath.image(selectedFile)
+        .sobel()
+        .run(outName)
+        console.log(niimath.outputDataType)
+        const t1 = performance.now();
+        console.log("niimath wasm took " + (t1 - t0) + " milliseconds.")
 
         // Create a download link for the processed file
         const url = URL.createObjectURL(outFile);

--- a/js/index.html
+++ b/js/index.html
@@ -61,7 +61,7 @@
         console.log("niimath wasm took " + (t1 - t0) + " milliseconds.")
 
         // test with a volume output
-        // const outName = 'out.nii';
+        // const outName = 'out.nii.gz';
         // const outFile = await niimath.image(selectedFile)
         // .sobel()
         // .run(outName)

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@niivue/niimath",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@niivue/niimath",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "esbuild": "^0.23.1"

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@niivue/niimath",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@niivue/niimath",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "esbuild": "^0.23.1"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/niimath",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/niimath",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -3,6 +3,8 @@ export class Niimath {
   constructor() {
     this.worker = null;
     this.operators = operators;
+    this.outputDataType = 'float'; // Possible datatypes are: char short int float double input
+    this.dataTypes = {char: 'char', short: 'short', int: 'int', float: 'float', double: 'double', input: 'input'};
   }
 
   init() {
@@ -25,18 +27,27 @@ export class Niimath {
     });
   }
 
+  setOutputDataType(type) {
+    if (Object.values(this.dataTypes).includes(type)) {
+      this.outputDataType = type;
+    } else {
+      throw new Error(`Invalid data type: ${type}`);
+    }
+  }
+
   image(file) {
-    return new ImageProcessor({ worker: this.worker, file, operators: this.operators });
+    return new ImageProcessor({ worker: this.worker, file, operators: this.operators, outputDataType: this.outputDataType });
   }
 }
 
 class ImageProcessor {
 
-  constructor({ worker, file, operators }) {
+  constructor({ worker, file, operators, outputDataType }) {
     this.worker = worker;
     this.file = file;
     this.operators = operators;
     this.commands = [];
+    this.outputDataType = outputDataType ? outputDataType : 'float'; // default to float
     this._generateMethods();
   }
 
@@ -116,7 +127,7 @@ class ImageProcessor {
         }
       };
 
-      const args = [this.file.name, ...this.commands, outName];
+      const args = [this.file.name, ...this.commands, outName, '-odt', this.outputDataType];
       if (this.worker === null) {
         reject(new Error('Worker not initialized. Did you await the init() method?'));
       }

--- a/js/src/niimathOperators.json
+++ b/js/src/niimathOperators.json
@@ -24,6 +24,19 @@
     "args": [],
     "help": "reslice to 1mm size in coronal slice direction with 256^3 voxels"
   },
+  "comply": {
+    "args": [
+      "nx",
+      "ny",
+      "nz",
+      "dx",
+      "dy",
+      "dz",
+      "f_high",
+      "isLinear"
+    ],
+    "help": "conform to axial slice with dx*dy*dzmm size and dx*dy*dz voxels. f_high bright clamping (0.98 for top 2%). Linear (1) or nearest-neighbor (0)"
+  },
   "crop": {
     "args": [
       "tmin",

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,7 +61,7 @@ sanitize:
 	$(CNAME) -O1 -g -Wno-deprecated -fsanitize=address -fno-omit-frame-pointer $(MFLAGS) $(UFLAGS) $(ZFLAGS) -o niimath
 
 wasm:
-	emcc -O3 $(MFLAGS) $(UFLAGS) -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["callMain", "ccall", "cwrap", "FS_createDataFile", "FS_readFile", "FS_unlink", "allocateUTF8", "getValue", "stringToUTF8", "setValue"]' -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_main", "_malloc", "_free"]' -s INVOKE_RUN=0 -o ../js/src/niimath.js
+	emcc -O3 $(MFLAGS) $(UFLAGS) $(ZFLAGS) -s USE_ZLIB=1 -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["callMain", "ccall", "cwrap", "FS_createDataFile", "FS_readFile", "FS_unlink", "allocateUTF8", "getValue", "stringToUTF8", "setValue"]' -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_main", "_malloc", "_free"]' -s INVOKE_RUN=0 -o ../js/src/niimath.js
 	# hint: consider further optimizations:
 	#   wasm-opt -O3 -o output.wasm niimath.wasm; rm niimath.wasm; mv output.wasm niimath.wasm
 	


### PR DESCRIPTION
This PR adds support for reading and writing gzip files (including `.mz3` and `.nii.gz`). The new `conform` option has also been activated in the javascript/wasm interface. 

Users can supply `.mz3` mesh files as inputs to niimath javascript/wasm to work directly on meshes with the `-mesh` options now. The limiting factor preventing this was the omission of zlib in the emscripten build. 