### PR TITLE
add ras and gz; include niimath version metadata

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@niivue/niimath",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@niivue/niimath",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "esbuild": "^0.23.1"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/niimath",
-  "version": "1.0.0-v1.0.20241222",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/niimath",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/niimath",
-  "version": "0.3.0",
+  "version": "1.0.0-v1.0.20241222",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {

--- a/js/src/niimathOperators.json
+++ b/js/src/niimathOperators.json
@@ -20,6 +20,10 @@
     "args": [],
     "help": "round voxels upwards to the nearest integer"
   },
+  "ras": {
+    "args": [],
+    "help": "reorder and flip dimensions to RAS orientation"
+  },
   "conform": {
     "args": [],
     "help": "reslice to 1mm size in coronal slice direction with 256^3 voxels"
@@ -73,6 +77,12 @@
   "floor": {
     "args": [],
     "help": "round voxels downwards to the nearest integer"
+  },
+  "gz": {
+    "args": [
+      "mode"
+    ],
+    "help": "NIfTI gzip mode (0=uncompressed, 1=compressed, else FSL environment; default -1)"
   },
   "h2c": {
     "args": [],
@@ -221,7 +231,7 @@
       "sigma",
       "scl"
     ],
-    "help": "edge enhancing unsharp mask (sigma in mm, not voxels; 1.0 is typical)"
+    "help": "edge enhancing unsharp mask (sigma in mm, not voxels [1 is typical]; scl is amount [0.5 medium, 1.0 heavy])"
   },
   "dog": {
     "args": [


### PR DESCRIPTION
This PR updates the javascript wasm build to include the `ras` and `gz` flags from niimath. 

The version in the npm package is now bumped to 1.0.0 (no reason not to be on 1.0 now)

closes #31
closes #32 
closes #34 
closes #35 
closes #36 

