### PR TITLE
Improve PyPI deployment configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,7 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install build tools
-        run: |
-          pip install build twine
-
-      - name: Build package
-        run: |
-          python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: casperdcl/deploy-pypi@v2
         with:
-          skip-existing: true
+          build: -s
+          upload: true

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ dist/
 build/
 __pycache__/
 *.py[cod]
+# Generated version file
+niimath/_dist_ver.py
+# scikit-build
+_skbuild/

--- a/niimath/__init__.py
+++ b/niimath/__init__.py
@@ -13,10 +13,29 @@ except ImportError: # pragma: nocover
         __version__ = "UNKNOWN"
 __all__ = ['bin', 'bin_path', 'main']
 
+import os
+import platform
 from pathlib import Path
 
-bin_path = Path(__file__).resolve().parent / "niimath"
+# Handle platform-specific binary naming
+system = platform.system()
+if system == "Windows":
+    bin_name = "niimath.exe"
+else:
+    bin_name = "niimath"
+
+# Check for binary in bin directory (standard installation)
+bin_path = Path(__file__).resolve().parent / "bin" / bin_name
+
+# Fallback to direct directory for backward compatibility
+if not bin_path.exists():
+    bin_path = Path(__file__).resolve().parent / bin_name
+
 bin = str(bin_path)
+
+# Make the binary executable on Unix systems
+if system != "Windows" and bin_path.exists():
+    os.chmod(bin, os.stat(bin).st_mode | 0o111)
 
 
 def main(args=None, **run_kwargs):
@@ -24,7 +43,7 @@ def main(args=None, **run_kwargs):
     Arguments:
       args: defaults to `sys.argv[1:]`.
       **run_kwargs: passed to `subprocess.run`.
-    Returns: `int` exit code from dcm2niix execution.
+    Returns: `int` exit code from niimath execution.
     """
     if args is None:
         import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,26 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "niimath/_dist_ver.py"
 write_to_template = "__version__ = '{version}'\n"
+
+[project]
+name = "niimath"
+description = "NIfTI arithmetic utilities"
+readme = "README.md"
+requires-python = ">=3.7"
+license = {file = "LICENSE"}
+authors = [
+  {name = "The niimath developers"}
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Medical Science Apps.",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent"
+]
+dynamic = ["version"]
+
+[project.urls]
+"Homepage" = "https://github.com/rordenlab/niimath"
+"Documentation" = "https://github.com/rordenlab/niimath"

--- a/setup.py
+++ b/setup.py
@@ -10,21 +10,19 @@ __version__ = get_version(root=".", relative_to=__file__)
 build_ver = ".".join(__version__.split(".")[:3]).split(".dev")[0]
 
 # Clean problematic pip env entries in CMakeCache
-cache_dir = Path(__file__).resolve().parent / "_skbuild"
-for cmake_file in cache_dir.rglob("CMakeCache.txt"):
-    cmake_file.write_text(re.sub(
-        r"^//.*$\n^[^#].*pip-build-env.*$", "",
-        cmake_file.read_text(),
-        flags=re.M
-    ))
+for i in (Path(__file__).resolve().parent / "_skbuild").rglob("CMakeCache.txt"):
+    i.write_text(re.sub("^//.*$\n^[^#].*pip-build-env.*$", "", i.read_text(), flags=re.M))
 
 # Build the package with scikit-build and CMake
 setup(
     name="niimath",
     use_scm_version=True,
     packages=["niimath"],
-    cmake_languages=("C",),  # "C" since niimath is a C program
+    cmake_languages=("C",),
     cmake_minimum_required_version="3.5",
-    # Optional: explicitly state where the source is
-    # package_dir={"": "src"},
+    entry_points={
+        "console_scripts": [
+            "niimath=niimath:main",
+        ],
+    }
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,4 +159,11 @@ if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
     endif()
 endif()
 
-install(TARGETS ${PROGRAMS} DESTINATION bin)
+# For Python package, we need to install to the package directory
+if(SKBUILD)
+    # scikit-build sets SKBUILD environment variable
+    # Install directly in the niimath package directory
+    install(TARGETS ${PROGRAMS} DESTINATION niimath)
+else()
+    install(TARGETS ${PROGRAMS} DESTINATION bin)
+endif()


### PR DESCRIPTION
## Changes

This PR improves the PyPI deployment configuration for niimath, following a similar approach to dcm2niix:

- Update setup.py with proper scikit-build configuration and add entry points for command-line usage
- Fix CMakeLists.txt to install binary in correct location for Python package
- Enhance __init__.py to find binary in multiple locations and handle platform-specific differences
- Update GitHub workflow to use casperdcl/deploy-pypi for publishing to PyPI
- Add project metadata to pyproject.toml
- Add generated files to .gitignore

## Testing

The changes have been tested locally by:
- Building source distribution
- Installing the package locally
- Verifying the binary is properly installed and accessible

These changes will allow users to simply `pip install niimath` and have a properly installed and functioning binary, while still leveraging platform-specific optimizations.