### PR TITLE
No longer require pyproject extra of scikit-build-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools_scm>=7", "scikit-build-core[pyproject]>=0.5"]
+requires = [
+  "setuptools_scm>=7",
+  "scikit-build-core>=0.11; python_version >= '3.9'",
+  "scikit-build-core[pyproject]>=0.5; python_version < '3.9'",
+]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
Since `scikit-build-core` 0.11, the `pyproject` extra has no effect and is provided only for backwards-compatibility. Update to `scikit-build-core>=0.11` without the `pyproject` extra, but do so conditionally for now, since we still advertise support for the end-of-life Python versions 3.7 and 3.8, and `scikit-build-core` 0.11 requires Python 3.9.

This corresponds to the combination of https://github.com/rordenlab/dcm2niix/commit/601568fcb7a05ffc0012845d1000a5673d4b7183 and https://github.com/rordenlab/dcm2niix/commit/c26a6aa3e711689c02962f10b027bb9c7b323d77.

This isn’t really mandatory – I could patch out the extra downstream if I make a Fedora package (since we no longer have a `python3-scikit-build-core+pyproject` metapackage), or I could ask the maintainers of the [`python-scikit-build-core`](https://src.fedoraproject.org/rpms/python-scikit-build-core) to restore the now-empty metapackage – but there is probably some value in following what `dcm2niix` did, since its structure appears to be a model for this project.

Using a `uv`-managed Python 3.8 interpreter, I confirmed that `python -m build` still works in a virtualenv on that version. I don’t have trivial access to a Python 3.7 interpreter anymore.