### PR TITLE
Correct license trove classifier from MIT to BSD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering :: Medical Science Apps.",
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: MIT License",
+  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
The license trove classifier claimed `MIT`, but the `LICENSE` file contains a `BSD-2-Clause` license.

As a follow-up, you might eventually consider dropping the trove classifier, now deprecated by PEP 639, and using https://packaging.python.org/en/latest/specifications/pyproject-toml/#license and https://packaging.python.org/en/latest/specifications/pyproject-toml/#license-files instead. However, PEP 639 support appeared in [`scikit-build-core` 11](https://github.com/scikit-build/scikit-build-core/releases/tag/v0.11.0), so you’ll have to be prepared to drop support for older versions of `scikit-build-core` and therefore for Python interpreters older than 3.9 in order to take advantage of it.