### PR TITLE
fix(windows): MSVC deface correctness (robustfov heap, corrupt zlib deflate, static link)

### DIFF
--- a/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
+++ b/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
@@ -8,9 +8,16 @@ set(ZLIB_CMAKE_ARGS
     -DBUILD_SHARED_LIBS:BOOL=OFF
 )
 
-# Only set MSVC static runtime if on Windows
+# Only set MSVC static runtime if on Windows. Use the CMAKE_MSVC_RUNTIME_LIBRARY
+# abstraction (with CMP0091=NEW) rather than a raw -MT flag: newer CMake sets the
+# runtime via that variable and its default (MultiThreadedDLL = /MD) otherwise
+# overrides a bare -MT, producing a /MD static lib whose __imp_* CRT imports fail
+# to link into the /MT niimath.exe (LNK2019). Static CRT here keeps niimath.exe
+# self-contained.
 if (MSVC)
-    list(APPEND ZLIB_CMAKE_ARGS -DCMAKE_C_FLAGS_RELEASE:STRING=-MT)
+    list(APPEND ZLIB_CMAKE_ARGS
+        -DCMAKE_POLICY_DEFAULT_CMP0091:STRING=NEW
+        -DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=MultiThreaded)
 endif()
 
 # Only add OS X architectures if explicitly defined
@@ -18,12 +25,29 @@ if(CMAKE_OSX_ARCHITECTURES)
     list(APPEND ZLIB_CMAKE_ARGS -DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES})
 endif()
 
-ExternalProject_Add(zlib
-    GIT_REPOSITORY "${git_protocol}github.com/ningfei/zlib.git"
-    GIT_TAG "${CLOUDFLARE_BRANCH}"
-    SOURCE_DIR cloudflare-zlib
-    BINARY_DIR cloudflare-zlib-build
-    CMAKE_ARGS ${ZLIB_CMAKE_ARGS}
-)
+# The Cloudflare fork's `gcc.amd64` branch is optimized with GCC/AMD64 inline
+# assembly. Under MSVC it compiles but its DEFLATE encoder emits a corrupt
+# stream for non-trivial data (a defaced/`-add` volume was unreadable even by
+# niimath's own inflate; simple near-binary data like `-edt` happened to
+# survive). INFLATE is fine, so reading Cloudflare-written files still works.
+# Use upstream madler zlib on MSVC; keep the fast Cloudflare fork on gcc/clang
+# (macOS/Linux), where its deflate is correct.
+if(MSVC)
+    ExternalProject_Add(zlib
+        GIT_REPOSITORY "${git_protocol}github.com/madler/zlib.git"
+        GIT_TAG "v1.3.1"
+        SOURCE_DIR madler-zlib
+        BINARY_DIR madler-zlib-build
+        CMAKE_ARGS ${ZLIB_CMAKE_ARGS}
+    )
+else()
+    ExternalProject_Add(zlib
+        GIT_REPOSITORY "${git_protocol}github.com/ningfei/zlib.git"
+        GIT_TAG "${CLOUDFLARE_BRANCH}"
+        SOURCE_DIR cloudflare-zlib
+        BINARY_DIR cloudflare-zlib-build
+        CMAKE_ARGS ${ZLIB_CMAKE_ARGS}
+    )
+endif()
 
 set(ZLIB_ROOT ${DEP_INSTALL_DIR})

--- a/js/tests/bsd.test.ts
+++ b/js/tests/bsd.test.ts
@@ -1,6 +1,7 @@
 // BSD build tests: the default @niivue/niimath WASM module. Verifies core math
 // works and that the BSD build now ships allineate (-allineate/-deface), which is
 // public-domain (AFNI 3dAllineate), not GPL.
+import { gzipSync } from 'node:zlib';
 import { describe, test, expect, beforeAll } from 'bun:test';
 import { BSD_MODULE, loadModule, makeNifti, run, voxel, type EmscriptenModule } from './helpers';
 
@@ -19,6 +20,23 @@ describe('BSD build (@niivue/niimath)', () => {
     expect(r.output).not.toBeNull();
     expect(voxel(r.output!, 0)).toBeCloseTo(10, 5);
     expect(voxel(r.output!, 5)).toBeCloseTo(15, 5);
+  });
+
+  test('gzip round-trip: reads .nii.gz input and writes .nii.gz output', async () => {
+    // Guards WASM compressed I/O (-DHAVE_ZLIB + emscripten -s USE_ZLIB=1). A build
+    // that dropped zlib would fail to READ the gzipped input (nonzero exit) or WRITE
+    // a real gzip stream (run() gunzips out.nii.gz, so a plain-bytes file named .gz
+    // fails to inflate and leaves output null). Exercising both directions in one
+    // run mirrors the user's `in.nii.gz -mul 1 out.nii.gz` case.
+    const input = { name: 'in.nii.gz', data: gzipSync(makeNifti(8, (i) => i)) };
+    const r = await run(
+      mod, log, [input],
+      ['in.nii.gz', '-mul', '1', 'out.nii.gz', '-odt', 'float'], 'out.nii.gz',
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.output).not.toBeNull(); // non-null ⇒ out.nii.gz was a valid gzip stream
+    expect(voxel(r.output!, 0)).toBeCloseTo(0, 5);
+    expect(voxel(r.output!, 5)).toBeCloseTo(5, 5);
   });
 
   test('-allineate registers a volume onto a base (BSD, public-domain)', async () => {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -189,6 +189,15 @@ if(NOT ${ZLIB_IMPLEMENTATION} STREQUAL "System")
         message(FATAL_ERROR "ZLIB_ROOT needs to be set to locate custom zlib!")
     endif()
 endif()
+# On MSVC, prefer the STATIC zlib (zlibstatic.lib) so niimath.exe is
+# self-contained. Upstream madler zlib (used on Windows — see
+# SuperBuild/External-CLOUDFLARE-ZLIB.cmake) installs BOTH a shared zlib.dll
+# and zlibstatic.lib; without this hint find_package(ZLIB) picks the DLL import
+# lib, leaving niimath.exe with a runtime dependency on zlib.dll that fails with
+# STATUS_DLL_NOT_FOUND (0xC0000135) when spawned outside the build tree.
+if(MSVC)
+    set(ZLIB_USE_STATIC_LIBS ON)
+endif()
 find_package(ZLIB REQUIRED)
 add_definitions(-DHAVE_ZLIB)
 target_include_directories(niimath PRIVATE ${ZLIB_INCLUDE_DIRS})

--- a/src/coreFLT.c
+++ b/src/coreFLT.c
@@ -3975,7 +3975,14 @@ staticx int nifti_robustfov(nifti_image *nim, double fovmm) {
 	size_t ns[3] = {1, (size_t)nd[0], (size_t)nd[0] * nd[1]};
 	// checked allocation: peak memory here is input + cropped output, so a near-whole-image
 	// crop can fail. The copy loop fills every output voxel, so no zero-init is needed.
-	flt *out = (flt *)_mm_malloc(nnew3D * nvol * sizeof(flt), 64);
+	// MUST be plain malloc, NOT _mm_malloc: this buffer becomes nim->data and is released
+	// by the NIfTI library's nifti_image_free() with plain free(). On glibc/macOS
+	// _mm_malloc() resolves to posix_memalign(), whose result IS free()-able, so the
+	// mismatch was silent there; on MSVC _mm_malloc() resolves to _aligned_malloc(),
+	// which MUST be paired with _aligned_free()/_mm_free() — plain free() on it corrupts
+	// the heap (STATUS_HEAP_CORRUPTION 0xC0000374 at teardown). A freshly read image's
+	// nim->data is only malloc-aligned anyway, so downstream ops already tolerate it.
+	flt *out = (flt *)malloc(nnew3D * nvol * sizeof(flt));
 	if (!out)
 		return 1; // allocation failed; input image left unchanged
 	for (int v = 0; v < nvol; v++)


### PR DESCRIPTION
## Windows/MSVC deface correctness

Fixes three Windows-only bugs that made `niimath -deface` (and `-robustfov`, `-add`, other real-data ops) produce a crash or an unreadable file on MSVC builds. macOS/Linux (gcc/clang) are unaffected — the fast Cloudflare zlib fork stays in use there.

### 1. robustfov heap corruption (`src/coreFLT.c`)
`nifti_robustfov` allocated the cropped `nim->data` with `_mm_malloc` but the NIfTI library frees it with plain `free()`. On glibc/macOS `_mm_malloc` is `posix_memalign` (free-able); on MSVC it is `_aligned_malloc`, so plain `free()` corrupts the heap (`STATUS_HEAP_CORRUPTION 0xC0000374` at teardown, after the output was written). Use plain `malloc` — alignment was never load-bearing for `nim->data` (a freshly read image is only malloc-aligned).

### 2. corrupt gzip output (`SuperBuild/External-CLOUDFLARE-ZLIB.cmake`, `src/CMakeLists.txt`)
The Cloudflare fork's `gcc.amd64` branch (GCC/AMD64 asm) compiles under MSVC but its **deflate** encoder emits a corrupt stream for non-trivial data — a defaced volume was unreadable even by niimath's own inflate, while near-binary `-edt` output survived. Inflate is fine, so reading Cloudflare-written files still works.
- Fetch upstream **madler zlib v1.3.1 on MSVC only**; keep Cloudflare on gcc/clang.
- Build the zlib subproject with the **static MSVC runtime** (`CMAKE_MSVC_RUNTIME_LIBRARY` + `CMP0091=NEW`).
- `ZLIB_USE_STATIC_LIBS` on MSVC so `find_package(ZLIB)` picks `zlibstatic.lib`, keeping `niimath.exe` self-contained (no `zlib.dll` → avoids `STATUS_DLL_NOT_FOUND 0xC0000135` when spawned outside the build tree).

### 3. gzip round-trip test (`js/tests/bsd.test.ts`)
Reads a `.nii.gz` input and writes a `.nii.gz` output in one run, guarding WASM compressed I/O.

### Verification
On Windows/MSVC: `-robustfov -deface` exits 0, the output decompresses to the full image and is re-readable by niimath, `dumpbin /dependents` shows only `KERNEL32.dll`, and the `-edt` path is unchanged. Discovered while getting the niimath sidecar working in BIDSvue (companion PR: niivue/BIDSvue#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
