### PR TITLE
docs: rewrite user-facing documentation with Diataxis structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,39 +4,42 @@
 
 ## About
 
-It is said that `imitation is the sincerest form of flattery`. This project emulates the popular [fslmaths](https://fsl.fmrib.ox.ac.uk/fslcourse/lectures/practicals/intro3/index.html) tool. fslmaths is a `general image calculator` and is not only one of the foundational tools for FSL's brain imaging pipelines (such as [FEAT](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT)), but has also been widely adopted by many tools. This popularity suggests that it fulfills an important niche. While scientists are often encouraged to discover novel solutions, it sometimes seems that replication is undervalued. Here are some specific reasons for creating this tool:
+niimath is an open-source clone of [fslmaths](https://fsl.fmrib.ox.ac.uk/fslcourse/lectures/practicals/intro3/index.html), the general image calculator of FSL. It accepts the same commands and gives equivalent results. It also adds operations that fslmaths does not have, such as mesh generation, affine and nonlinear registration, defacing, motion correction, slice-time correction, phase unwrapping and distortion correction.
 
-1. While fslmaths is provided without charge, it is not [open source](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence). This limits its inclusion in other projects, in particular for commercial exploitation.
-2. Using an open source license allows niimath to build with open source libraries that the FSL team can not use. Specifically, an accelerated zlib ([zlib-ng](https://github.com/zlib-ng/zlib-ng), the release baseline) provides dramatically faster performance than the public domain library used by fslmaths. n.b. We previously helped update the [CloudFlare zlib](https://github.com/cloudflare/zlib/pull/19) fork that allows recent FSL releases to use an accelerated library, improving the speed for all FSL tools; niimath's releases now default to zlib-ng, which is also fast on arm64 and correct on Windows.
-3. Minimal dependencies allow easy distribution, compilation and development. For example, it can be compiled for MacOS, Linux and Windows (fsl can not target Windows).
-4. Designed from ground up to optionally use parallel processing (OpenMP and CloudFlare-enhanced [pigz](https://github.com/madler/pigz)).
-5. Most programs are developed organically, with new features added as need arises. Cloning an existing tool provides a full specification, which can lead to optimization. niimath uses explicit single and double precision pipelines that allow the compiler to better use advanced instructions (every x86_64 CPU provides SSE, but high level code has trouble optimizing these routines). The result is that modern compilers are able to create operations that are limited by memory bandwidth, obviating the need for [hand tuning](https://github.com/neurolabusc/simd) the code.
-6. Developing a robust regression testing dataset has allowed us to discover a few edge cases where fslmaths provides anomalous or unexpected answers (see below). Therefore, this can benefit the popular tool that is being cloned.
-7. While the code is completely reverse engineered, the FSL team has been gracious to allow us to copy their error messages and help information. This allows true plug in compatibility. They have also provided pseudo code for poorly documented routines. This will allow the community to better understand the actual algorithms.
-8. This project provides an open-source foundation to introduce new features that fill gaps with the current FSL tools (e.g. unsharp, sobel, resize functions). For future releases, Bob Cox has graciously provided permission to use code from [AFNI's](https://afni.nimh.nih.gov) 3dTshift and 3dBandpass tools that provide performance unavailable within [FSL](https://neurostars.org/t/bandpass-filtering-different-outputs-from-fsl-and-nipype-custom-function/824). Including them in this project ensures they work in a familiar manner to other FSL tools (and leverage the same environment variables). Note that the slice-timing command niimath actually ships, `-stc`, did **not** draw on that permission: it is a clean-room BSD-2 implementation that contains no AFNI code, because `3dTshift.c` and its FFT are GPL-2. See the License section.
+fslmaths is one of the foundations of the FSL pipelines, such as [FEAT](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FEAT), and many other tools call it. This popularity shows that it fills an important role. Scientists are often encouraged to find new solutions, but replication has value too. niimath exists for these reasons:
 
-The Reason to use fslmaths instead of niimath:
+1. fslmaths is free of charge, but it is not [open source](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence). This limits its use in other projects, in particular commercial ones.
+2. An open-source license lets niimath use libraries that the FSL team cannot. The release builds use [zlib-ng](https://github.com/zlib-ng/zlib-ng), an accelerated zlib that is much faster than the public domain zlib used by fslmaths. zlib-ng is also fast on arm64 and correct on Windows. We previously helped update the [CloudFlare zlib](https://github.com/cloudflare/zlib/pull/19) fork, which lets recent FSL releases use an accelerated library and speeds up every FSL tool.
+3. niimath has minimal dependencies. This makes it easy to distribute, compile and develop. It compiles for macOS, Linux and Windows. FSL cannot target Windows.
+4. niimath was designed from the start for optional parallel processing, with OpenMP and the CloudFlare-enhanced [pigz](https://github.com/madler/pigz).
+5. Most programs grow organically as needs arise. A clone starts with a full specification, which permits optimization. niimath uses explicit single and double precision pipelines, so the compiler can use the SIMD instructions that every x86_64 CPU provides but that high-level code rarely exploits. Modern compilers make these operations limited by memory bandwidth, so no [hand tuning](https://github.com/neurolabusc/simd) is needed.
+6. A robust regression test set has found edge cases where fslmaths gives anomalous or unexpected answers. See [Compatibility with fslmaths](#compatibility-with-fslmaths). This feedback benefits fslmaths too.
+7. The code is fully reverse engineered, but the FSL team allowed us to copy their error messages and help text. This gives true plug-in compatibility. They also supplied pseudo code for poorly documented routines, so the community can understand the actual algorithms.
+8. niimath is an open-source base for features that fill gaps in FSL, such as `-unsharp`, `-sobel` and `-resize`. Bob Cox gave permission to use code from [AFNI's](https://afni.nimh.nih.gov) 3dTshift and 3dBandpass tools, which give performance that [FSL](https://neurostars.org/t/bandpass-filtering-different-outputs-from-fsl-and-nipype-custom-function/824) does not. Including them in this project makes them work like the other FSL tools and use the same environment variables. The slice-timing command that niimath ships, `-stc`, does **not** use that permission. It is a clean-room BSD-2 implementation with no AFNI code, because `3dTshift.c` and its FFT are GPL-2. See [License](#license).
 
-1. niimath is new and largely untested software. There may be unknown corner cases where produces poor results. fslmaths has been used for years and therefore has been battle tested. In the few instances where fslmaths generates results that bear no resemblance to its own documentation (as described below), one could argue it is the `correct` result (with comparison to itself). However, many tools may have been developed to assume this loss of high frequency signal and these tools may not perform well when provided with the result specified in the documentation.
+There is one reason to use fslmaths instead of niimath. niimath is newer and less tested, so unknown corner cases may give poor results. fslmaths has been in use for years. In the few cases where fslmaths differs from its own documentation (described below), you can argue that its result is the `correct` one, because it agrees with itself. Other tools may have been built to expect that behavior, such as the loss of high frequency signal, and may perform worse when given the documented result.
 
 ## Installation
 
-You can get niimath using several methods:
+Choose one of these methods:
 
- - (Recommended) Download latest compiled release from [Github release web page](https://github.com/rordenlab/niimath/releases).
- - (Recommended) Download latest compiled release from [PyPI](https://pypi.org/project/niimath/):
-  * `pip install niimath`
- - (Recommended) You can also download from the command line for Linux, MacOS and Windows:
-  * `curl -fLO https://github.com/rordenlab/niimath/releases/latest/download/niimath_lnx.zip`
-  * `curl -fLO https://github.com/rordenlab/niimath/releases/latest/download/niimath_macos.zip`
-  * `curl -fLO https://github.com/rordenlab/niimath/releases/latest/download/niimath_win.zip`
- - (Developers) Download the source code from [GitHub](https://github.com/rordenlab/niimath), the next section describes how to build the software.
+- (Recommended) Download the latest compiled release from the [GitHub releases page](https://github.com/rordenlab/niimath/releases).
+- (Recommended) Install from [PyPI](https://pypi.org/project/niimath/) with `pip install niimath`.
+- (Recommended) Download from the command line on Linux, macOS or Windows:
+
+```
+curl -fLO https://github.com/rordenlab/niimath/releases/latest/download/niimath_lnx.zip
+curl -fLO https://github.com/rordenlab/niimath/releases/latest/download/niimath_macos.zip
+curl -fLO https://github.com/rordenlab/niimath/releases/latest/download/niimath_win.zip
+```
+
+- (Developers) Download the source code from [GitHub](https://github.com/rordenlab/niimath) and build it. See [Compilation](#compilation).
 
 ## Compilation
 
 ### CMake (recommended)
 
-The easiest way to build niimath on a Unix computer is to use cmake. OpenMP is enabled by default (used by affine registration and optionally by core operations):
+On Linux and macOS, build with CMake. OpenMP is enabled by default. Affine registration uses it, and the core operations can use it:
 
 ```
 git clone https://github.com/rordenlab/niimath.git
@@ -44,9 +47,9 @@ cd niimath; mkdir build; cd build; cmake ..
 make
 ```
 
-On macOS, OpenMP requires Homebrew's libomp: `brew install libomp`. To disable OpenMP, use `cmake -DUSE_OPENMP=OFF ..`. Optional zstd compression support is auto-detected; install with `brew install zstd` (macOS) or `apt install libzstd-dev` (Linux).
+On macOS, OpenMP needs Homebrew's libomp. Install it with `brew install libomp`. To disable OpenMP, use `cmake -DUSE_OPENMP=OFF ..`. zstd compression support is detected automatically. To enable it, install zstd with `brew install zstd` (macOS) or `apt install libzstd-dev` (Linux).
 
-Likewise, if you are compiling on Windows using cmake:
+On Windows:
 
 ```
 git clone https://github.com/rordenlab/niimath.git
@@ -56,7 +59,7 @@ cmake --build .
 
 ### Makefile (alternative)
 
-You can compile the software by running the terminal command `make` from the project's `src` folder. This works with both Clang/LLVM and gcc on Linux and macOS:
+Run `make` in the `src` folder. This works with Clang/LLVM and gcc on Linux and macOS:
 
 ```
 git clone https://github.com/rordenlab/niimath.git
@@ -64,11 +67,10 @@ cd niimath/src
 make
 ```
 
-The default build includes OpenMP for all operations. On macOS this requires `brew install libomp`. To disable OpenMP, use `OMP=0 make`. Other Makefile options:
+The default build includes OpenMP for all operations. On macOS this requires `brew install libomp`. Plain `make` links the system zlib. CMake release builds default to zlib-ng (`ZLIB_IMPLEMENTATION`). Other Makefile options:
 
 ```
 OMP=0 make             # Disable OpenMP
-# zlib: CMake release builds default to zlib-ng (ZLIB_IMPLEMENTATION); plain make uses system -lz
 make debug             # Debug build (-g, no optimization)
 make ubsan             # Lightweight undefined-behavior checks (OpenMP-safe on macOS)
 make sanitize          # AddressSanitizer build
@@ -79,24 +81,22 @@ make wasm-wasi         # Experimental zlib-free WASI compute backend (needs Zig)
 make wasm-emcc-core    # Feature-matched zlib-free Emscripten build (WASI benchmark baseline)
 ```
 
-You can also compile this project to Web Assembly so it can be embedded in a web page, as shown in the [live demo](https://niivue.github.io/niivue-niimath/).
+### Optional GPL module
 
-#### Optional GPL `-spm_coreg` module
-
-The `-spm_coreg` (SPM rigid-body coregistration) and `-spm_deface` (SPM-based defacing) commands live in the separate GPL-2 [niimath_gpl](https://github.com/rordenlab/niimath_gpl) submodule and are OFF by default, so ordinary builds stay BSD-2-Clause. To build them, initialize the submodule and pass `GPL=1` (Makefile) or `-DENABLE_GPL=ON` (CMake). Run both commands from the repository root so the paths resolve:
+The `-spm_coreg` (SPM rigid-body coregistration) and `-spm_deface` (SPM-based defacing) commands live in the separate GPL-2 [niimath_gpl](https://github.com/rordenlab/niimath_gpl) submodule. They are off by default, so ordinary builds stay BSD-2-Clause. To build them, initialize the submodule and pass `GPL=1` (Makefile) or `-DENABLE_GPL=ON` (CMake). Run both commands from the repository root so the paths resolve:
 
 ```
 git submodule update --init src/GPL    # or clone with --recurse-submodules
 make -C src GPL=1
 ```
 
-A binary built this way is a GPL-2 combined work (its version string ends in ` GPL`); without the module `-spm_coreg`/`-spm_deface` report a clear error and the build stays BSD-2 (` BSD`). The GPL module computes only the rigid transform; niimath's BSD code applies it (reslicing and mask warping shared with `-allineate`/`-deface`).
+A binary built this way is a GPL-2 combined work. Its version string ends in ` GPL`. Without the module, the version string ends in ` BSD`, and `-spm_coreg` and `-spm_deface` report a clear error. The GPL module computes only the rigid transform. niimath's BSD code applies it, with the same reslicing and mask warping that `-allineate` and `-deface` use.
 
-When built with OpenMP, `-spm_coreg`/`-spm_deface` parallelize a single registration (the per-evaluation histogram and smoothing); results agree across thread counts to within the SPM golden tolerance (the histogram reduction sums in a thread-count-dependent order, so it is not guaranteed bit-identical across different team sizes, though it is deterministic at a fixed thread count). Control threads with `OMP_NUM_THREADS=N` or `-p N` (place `-p` before `-spm_coreg`). For batch runs of many subjects, prefer one subject per process with `OMP_NUM_THREADS=1` rather than threading each registration.
+With OpenMP, `-spm_coreg` and `-spm_deface` parallelize one registration (the per-evaluation histogram and smoothing). Results agree across thread counts within the SPM golden tolerance. They are deterministic at a fixed thread count, but they are not guaranteed bit-identical across different thread counts, because the histogram reduction sums in a thread-count-dependent order. Control threads with `OMP_NUM_THREADS=N` or `-p N` (place `-p` before `-spm_coreg`). For batches of many subjects, run one subject per process with `OMP_NUM_THREADS=1` instead of threading each registration.
 
 ### Windows (command line)
 
-For Windows, using the cmake method described above is highly recommended. However, you can also compile the project directly from the command line (here without the `-DHAVE_ZLIB` directive, so gz files will not be supported):
+On Windows, the CMake method above is recommended. You can also compile directly from the command line. This example omits `-DHAVE_ZLIB`, so the binary cannot read or write `.gz` files:
 
 ```
 cl /Feniimath niimath.c core.c tensor.c bwlabel.c bw.c core32.c core64.c fdr.c meshify.c MarchingCubes.c quadric.c base64.c radixsort.c unifize.c nifti_io.c -DNII2MESH
@@ -104,7 +104,7 @@ cl /Feniimath niimath.c core.c tensor.c bwlabel.c bw.c core32.c core64.c fdr.c m
 
 ### Linux universal binary
 
-Simply running `make` in the `src` folder should compile niimath on Linux. However, the resulting executable will only work with specific versions of Linux. If you want to make a universal Linux release you can use [holy-build-box](https://github.com/FooBarWidget/holy-build-box). Be aware that this uses an old version of the gcc compiler (4.8.5), so the resulting performance may not be optimized for your system.
+`make` in the `src` folder builds a binary that works only on specific Linux versions. To build a binary that runs on many Linux versions, use [holy-build-box](https://github.com/FooBarWidget/holy-build-box). It uses an old gcc (4.8.5), so the binary may not be fully optimized for your system.
 
 ```
 git clone https://github.com/rordenlab/niimath
@@ -115,110 +115,461 @@ exit
 sudo chown $(whoami) ./niimath/src/niimath
 ```
 
-## JavaScript/WebAssembly
+## JavaScript and WebAssembly
 
-To read the WASM specific README, please click [here](./js/README.md). The rest of this README is for the `niimath` CLI program.
+niimath compiles to WebAssembly, so you can use it in web pages and Node.js projects. See the [live demo](https://niivue.github.io/niivue-niimath/), which links to source code and instructions, and the [@niivue/niimath README](https://github.com/rordenlab/niimath/blob/master/js/README.md). The rest of this README describes the `niimath` command-line program.
 
 ## Usage
 
-niimath provides the same commands as fslmaths, so you can use it just as you would fslmaths. If you are brave, you can even rename it fslmaths and use it as a drop in replacement. You can also modify your environment variables to unleash advanced features:
+niimath accepts the same commands as fslmaths, so you can use it as you would use fslmaths. You can even rename it `fslmaths` and use it as a drop-in replacement. Run `niimath` with no arguments to print the full list of operations. The general form is:
 
- - Just like fslmaths, it uses your [`FSLOUTPUTTYPE` Environment Variable ](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslEnvironmentVariables) to determine output file format. Unix users can specify `export FSLOUTPUTTYPE=NIFTI_GZ`, `export FSLOUTPUTTYPE=NIFTI`, or `export FSLOUTPUTTYPE=NIFTI_ZST` (zstd compressed, requires zstd support) from the command line or profile. Windows users can use `set` instead of `export`.
- - To turn on parallel processing and threading, you can either set the environment variable `export AFNI_COMPRESSOR=PIGZ`. If the environment variable `AFNI_COMPRESSOR` does not exist, or is set to any value other than `PIGZ` you will get single threaded compresson.
+```
+niimath [-dt <datatype>] <first_input> [operations and inputs] <output> [-odt <datatype>]
+```
 
-niimath has a few features not provided by fslmaths:
+Two environment variables control the output:
 
- - `bandpass <hp> <lp> <tr>`: Butterworth filter, highpass and lowpass in Hz,TR in seconds (zero-phase 2*2nd order filtfilt)
- - `bptfm <hp> <lp>`        : Same as bptf but does not remove mean (emulates fslmaths < 5.0.7)
- - `bwlabel <conn>`         : Connected component labelling for non-zero voxels (conn sets neighbors: 6, 18, 26)
- - `ceil`                   : round voxels upwards to the nearest integer
- - `crop <tmin> <tsize>`    : remove volumes, starts with 0 not 1! Inputting -1 for a size will set it to the full range
- - `dehaze <mode>`          : set dark voxels to zero (mode 1..5; higher yields more surviving voxels)
- - `detrend`                : remove linear trend (and mean) from input
- - `demean`                 : remove average signal across volumes (requires 4D input)
- - `edt`                    : estimate Euler Distance Transform (distance field). Assumes isotropic input
- - `floor`                  : round voxels downwards to the nearest integer
- - `mod`                    : modulus fractional remainder - same as '-rem' but includes fractions
- - `otsu <mode>`            : binarize image using Otsu''s method (mode 1..5; higher yields more bright voxels))
- - `power <exponent>`       : raise the current image by following exponent
- - `resize <X> <Y> <Z> <m>` : grow (>1) or shrink (<1) image. Method <m> (0=nearest,1=linear,2=spline,3=Lanczos,4=Mitchell)
- - `robustfov [mm]`         : crop to a robust field of view (default 170mm) from the top of the head down, removing lower head/neck (emulates FSL robustfov); adjusts dim and sform/qform
- - `round`                  : round voxels to the nearest integer
- - `sobel`                  : fast edge detection
- - `sobel_binary`           : sobel creating binary edge
- - `tensor_2lower`          : convert FSL style upper triangle image to NIfTI standard lower triangle order
- - `tensor_2upper`          : convert NIfTI standard lower triangle image to FSL style upper triangle order
- - `tensor_decomp_lower`    : as tensor_decomp except input stores lower diagonal (AFNI, ANTS, Camino convention)
- - `trunc`                  : truncates the decimal value from floating point value and returns integer value
- - `unsharp  <sigma> <scl>` : edge enhancing unsharp mask (sigma in mm, not voxels; 1.0 is typical for amount (scl))
- - `dog <sPos> <sNeg>`      : difference of gaussian with zero-crossing edges (positive and negative sigma mm)
- - `dogr <sPos> <sNeg>`     : as dog, without zero-crossing (raw rather than binarized data)
- - `dogx <sPos> <sNeg>`    : as dog, zero-crossing for 2D sagittal slices
- - `dogy <sPos> <sNeg>`    : as dog, zero-crossing for 2D coronal slices
- - `dogz <sPos> <sNeg>`    : as dog, zero-crossing for 2D axial slices
- - `mesh`                  : see separate section below
- - `qform <code>`          : set qform code
- - `sform <code>`          : set sform code
- - `unifize [-GM]`         : bias field correction (adapted from AFNI 3dUnifize); optional `-GM` also scales gray-matter intensity toward a common target
- - `allineate <base> [opts]`: affine registration to match 'base' (from AFNI 3dAllineate)
-   - opts: `-cost XX` (`fast`/`fastx` [adaptive default], `fasthel`, `fastcr`, `hel`, `nmi`, `lpc`, `lpa`, `ls`) `-cmass` `-nocmass` `-source_automask`
-   - `-warp XX` (sho, shr, srs, aff [default]) `-interp XX` (NN, linear [default], cubic)
-   - `-final XX` (NN, linear, cubic [default]) or `-nearest` `-linear` `-cubic`
-   - `-fill XX` (auto [default], zero, nan): out-of-FOV output fill. `auto` uses 0, or the source's darkest voxel if it is negative (CT/Hounsfield air ≈ -1000, so out-of-FOV reads as air rather than soft tissue); `zero` is always 0 (byte-identical to the historical behavior for positive-only MRI); `nan`. Not available for `deface`, whose fill stays the image minimum
-   - `-master <grid>`: estimate at the base resolution but reslice the result onto `<grid>` (must share the base world frame, e.g. a higher-resolution template)
-   - `-savemat out.json`: save the fitted world-space `fixed_to_moving` affine (and its inverse) as self-describing JSON. `-applymat in.json`: reslice the moving image onto `base` using a saved affine, doing **no** registration (exclusive with the registration/seed options; use `-nearest` for label/atlas volumes)
-   - Registration seeds (applied to the moving image before the fit): `-com` (reset the origin to the brightness center of mass), `-sym`/`-symd`/`-symb` (fold a midsagittal-plane correction into the header; `-symd` de-obliques the frame first, `-symb` auto-competes both), `-nosagseed` (disable the in-MSP rigid seed `-sym` runs by default), `-zoom` (relax the scale range for abnormal-size subjects, e.g. infant vs adult template)
-   - Skull-stripping is `deface` with a brain mask; to crop the field of view first, chain `-robustfov` before `-allineate`. Together these make niimath a superset of the standalone `allineate` registration tool.
-   - **Fast engine (the default):** a bare `-allineate`, `-cost fast`, and `-cost fastx` all select the adaptive clean-room estimator. On a whole-head base it independently fits HEL and correlation-ratio coarse candidates, selects by HEL dependence×overlap, and continues once through the finer HEL stages. A hard-zeroed/skull-stripped base activates the deeper rigid-HEL, scale-bracketed-HEL, and CR-seeded multi-start, with fine-level arbitration before final affine polish. Use `-cost fasthel` to force the HEL-only fast trajectory or `-cost fastcr` to force correlation-ratio only; use `-cost hel`/`nmi`/`lpc`/`lpa`/`ls` for the ordinary AFNI-style engine. The fast estimator is SPM/FLIRT-inspired, multiresolution, and typically several times faster. It runs a fixed schedule with internal sampling, so it rejects `-warp`/`-interp`/`-source_automask`/`-dark_automask`/`-zoom` (use an ordinary cost for those) — but the `-com`/`-sym`/`-symd`/`-symb` header seeds work with it. Default/`-cmass` chooses the supplied-affine or COM-recentered initialization from dependence×overlap, `-com` forces COM, and `-nocmass` forces the supplied affine; `-final`/`-master`/`-savemat` are also honored. `-cost` is last-one-wins. `-weight <img>` (a base-space region image, 3D with dims and world frame matching `base`) is an AFNI 3dAllineate-style **graded** weight: it is normalized to `[0, 1]` (divide by max) and applied per base voxel — a voxel weighted 0 is excluded, one near 1 dominates. It is **not an exclusion mask**; keep the out-of-ROI head attenuated (nonzero), because zeroing the whole exterior leaves global scale underdetermined and the cross-modal fit collapses into the scalp (an AFNI-style whole-head weight anchors absolute size). BOTH engines honor it: the ordinary engine loads it internally in place of its manufactured autoweight, while the fast engine applies it only at the finest 2 mm stage so coarse capture and global-scale selection stay whole-head. `-weight` is rejected with stdin (`-`) and `-applymat`. A background-only weight is rejected. If the implicit default fast engine fails and falls back to ordinary Hellinger, the weight remains honored; explicit fast selectors never silently switch engines.
- - `deface <tmpl> <mask> [opts]`: remove voxels using a template-space mask. Registers the input to `tmpl` (affine), inverts the transform, warps `mask` onto the input's native grid, and sets voxels where the warped mask < 0.5 to the image's finite minimum (≈0 for typical MRI; the input itself is never resampled). `mask` is in `tmpl` space: ≥0.5 = keep, <0.5 = remove. The mask determines what is removed — supply a brain mask to skull-strip (keep the brain) or a face mask to deface (remove the face).
-   - opts: `-cost XX` (`fast`/`fastx` [adaptive default], `fasthel`, `fastcr`, `hel`, `nmi`, `lpc`, `lpa`, `ls`) `-cmass`/`-nocmass` tuning + `-final`/`-nearest`/`-linear`/`-cubic` (default final: linear). Like `-allineate`, deface defaults to the adaptive fast engine; `-cost fasthel`/`fastcr` force one fast cost and `-cost hel` selects the ordinary AFNI-style engine. Fast cannot honor `-warp`/`-interp`/`-source_automask`/`-dark_automask` (use `-cost hel`). The seed/matrix/master workflow options (`-savemat`/`-applymat`/`-com`/`-sym`/`-symd`/`-symb`/`-nosagseed`/`-zoom`/`-master`) apply to `-allineate` only and are **rejected** here
-   - **Breaking change:** the former `-skullstrip <tmpl> <mask>` command was removed — it ran the identical operation. Replace `-skullstrip` with `-deface` (supply your brain mask); the result is unchanged.
- - `reface <tmpl> <shell> <weight> [opts]`: **anonymize** by face replacement (emulates AFNI `afni_refacer2 -mode_reface`). Registers the subject to `tmpl`, back-projects the signed template-space face-replacement `shell` onto the **original subject grid**, and composites an anonymized image (shell > 0 → the shell scaled by a brightness-match factor, shell == 0 → keep the subject, shell < 0 → zero), with an edge blend inside the replaced region. Output stays on the subject grid. Works with both engines and honors `-weight` (the `weight` argument is **required** — it is reused as the registration weight); opts are the `-cost` tuning as for `deface` (the shell back-projection is always nearest-neighbour, so `-final` does not apply). For privacy the coverage diagnostic **fails closed**: if little of the shell mapped into the subject FOV (<10%, a likely registration failure) `-reface` refuses to write the possibly-unanonymized image and returns an error.
- - `qwarp <base>` (built only with `QWARP=1`): **nonlinear (deformable) registration** to `base`, an attributed port of AFNI `3dQwarp -blur 0 3`. It takes a single `base` argument and has **no sub-options** of its own, but it is an ordinary chain operation — it produces a warped image on the `base` grid, so you may chain further ops after it. The input must **already** be unifized, skull-stripped, affine-aligned, and share the `base` grid (same dims + world frame). Off by default (memory/CPU-heavy, impractically slow in WebAssembly) and depends on the allineate engine, so it is unavailable in an `AL=0` build.
- - `romeo <mag|none> [opts]`: **ROMEO phase unwrapping** — a faithful MIT-licensed C port of [ROMEO.jl](https://github.com/korbinian90/ROMEO.jl) plus the [MriResearchTools.jl](https://github.com/korbinian90/MriResearchTools.jl) helpers its command-line app uses. The chain image is the wrapped phase (3D, or 4D with echoes on dim 4); the magnitude is a **required positional argument** — pass the literal `none` to unwrap without one. An ordinary chain operation, so further niimath operations may follow. Enabled by default; `ROMEO=0 make` / `-DENABLE_ROMEO=OFF` omits it.
-   - opts: `-t <TEs>` (echo times in ms: `16.8`, `16.8,38.56`, `'[16.8,38.56]'`, `epi [te]` — quote the bracket form for the shell; **required for multi-echo input**, optional for a single echo) `-k nomask|robustmask|qualitymask [thr, default 0.1]|<mask file>` `-w romeo|romeo2|romeo3|romeo4|romeo6|<up to 6 bits e.g. 1010>` (bare `romeo` resolves to `romeo3` when a magnitude is supplied and `romeo4` when it is not) `-template <n>` `-i` (individual, not temporal) `-temporal-uncertain-unwrapping [x]` `-g` (correct global n2π offset) `-q`/`-Q` (quality maps) `-B [name]` (B0 field map in Hz) `-B0-phase-weighting phase_snr|phase_var|average|TEs|mag|simulated_mag` `-no-phase-rescale` (alias `-no-rescale`) `-no-mask-out` `-v`
-   - side outputs use `nifti_save` postfixes on the output name: `<out>_mask` (only when a mask was actually computed — `-k nomask` writes none), `<out>_quality` (`-q`), `<out>_quality_1..6` (`-Q`; a map that is uniformly 1.0 in the interior is skipped, as upstream), `<out>_B0` and `<out>_B0_snr` (`-B`); they honor `FSLOUTPUTTYPE`, and `-gz` **when it precedes `-romeo`** — the companions are written during the operation, so a later `-gz` only reaches the main output
-   - the phase is rescaled to `[-π, π]` following `readphase` unless `-no-phase-rescale` is given; because that inspects the *unscaled stored* values, `-romeo` must be the **first** computational operation when rescaling is active
-   - `-B` computes B0 **without** MCPC-3D-S phase-offset correction, which ROMEO's own multi-echo `-B` silently enables; the maps therefore correspond to `romeo --compute-B0 --phase-offset-correction off`, and niimath says so on stderr rather than implying full equivalence. Without a magnitude, ROMEO's SNR map collapses to a single value (the substituted `exp(-TE/20)` decay is voxel-independent); niimath writes that same constant across the working grid instead.
-   - **Not yet ported** (rejected with a specific message rather than silently ignored): `-u`, `-e`, `-threshold`, `-w bestpath`, `-max-seeds > 1`, `-merge-regions`, `-correct-regions`, `-wrap-addition != 0`, `-fix-ge-phase`. MCPC-3D-S phase-offset correction and multi-channel (5D) input are out of scope.
-   - please cite Dymerska, B. et al. 2020, *Magnetic Resonance in Medicine*, [doi:10.1002/mrm.28563](https://doi.org/10.1002/mrm.28563)
- - `unwarp <map> <axis>`: **EPI distortion correction** — resample the chain image through a scalar displacement map in millimetres (as written by `--medic`, see below). An ordinary chain operation, so further niimath operations may follow. Enabled by default with `--medic`; `MEDIC=0 make` / `-DENABLE_MEDIC=OFF` omits it.
-   - `<map>` is 3D (broadcast over every frame) or 4D matching the input's frame count, and must share the input's dimensions and world transform
-   - `<axis>` is `i`, `j` or `k` (equivalently `x`, `y`, `z`). A trailing `-` is accepted and **ignored**: the sign already lives in the stored map, so negating again would double-correct. `--medic --phase-encoding-direction` is deliberately the opposite — it **honors** the suffix — so pass the full BIDS value there and do not worry about it here
-   - resampling uses an unnormalized Lanczos-5 windowed sinc applied separably in 3D, with zero fill outside the field of view and no Jacobian intensity modulation — matching the reference implementation's measured behavior (measured; see the `medic_bench` repository)
- - `moco [-1Dfile <path>]`: **rigid-body motion correction** — registers every volume of a 4D series onto volume 0 and replaces the image with the corrected series: `niimath bold -moco out`. Add `-1Dfile` to also write the six motion parameters per volume: `niimath bold -moco -1Dfile out.1D out`; the parameter filename must end in `.1D`. The input must be 4D with more than one volume (correction runs in float32, so `-dt double` is rejected); an ordinary chain operation, so further niimath operations may follow. A clean-room BSD-2 implementation of the method of Cox & Jesmanowicz (*Magnetic Resonance in Medicine* 42:1014-1018, 1999), the algorithm behind AFNI `3dvolreg`. Enabled by default on every platform, including the WebAssembly build; `MOCO=0 make` (or `-DENABLE_MOCO=OFF`) omits it.
-   - the parameter file is compatible with AFNI's `-1Dfile`: six columns `roll pitch yaw dS dL dP`, one row per volume — rotations in degrees counter-clockwise about the I-S, R-L and A-P axes, shifts in mm toward Superior, Left and Posterior — recording the **correction** that was applied, not the estimated motion. Row 0 is all zeros (the base registers to itself)
- - `stc --slicetiming <t0,t1,...|@file> [-tzero <sec>]`: **slice-time correction** — shifts every voxel time series of a 4D series so that all slices share one temporal origin: `niimath bold -stc --slicetiming @times.1D out`. `--slicetiming` is required, case-sensitive, and must come first; it takes either one comma-separated list of slice acquisition times in **seconds** or an AFNI-style `@file` (whitespace- or comma-separated, `#` starts a comment). Supply exactly one value per slice along storage axis `k`, in slice-index order — a count that does not match `nz` is an error, not a silently truncated list. Optional `-tzero <sec>` sets the common time point (default: the arithmetic mean of the supplied times) and must lie within their `[min, max]`. The input must be a scalar 4D image with at least 5 volumes, a finite positive `pixdim[4]`, and a usable temporal unit in `xyzt_units` — seconds, milliseconds or microseconds; niimath will not assume seconds. Correction runs in float32, so `-dt double` is rejected; an ordinary chain operation, so further niimath operations may follow. Only `toffset` changes in the header (to the common time point, in the header's own time units); geometry, TR and the spatial transforms are untouched. A clean-room BSD-2 implementation of the default Fourier method (detrend → interpolate → retrend) of AFNI `3dTshift`, whose source is GPL-2 and was used only as a black-box oracle. Enabled by default on every platform, including the WebAssembly build; `STC=0 make` (or `-DENABLE_STC=OFF`) omits it.
-   - v1 corrects along storage axis `k` only. `test/stc_slicetiming.py` is a standard-library-only helper that reads a BIDS sidecar and prints the `--slicetiming` argument, honoring `SliceEncodingDirection` (`k` passes through, `k-` is reversed into slice-index order, `i`/`j` are rejected) and hard-erroring if the sidecar's `RepetitionTime` disagrees with the unit-normalized header TR: `niimath bold.nii.gz -stc --slicetiming "$(python3 test/stc_slicetiming.py bold.nii.gz)" out.nii.gz`
- - `spm_coreg <ref> [opts]`: SPM rigid-body coregistration of the chain image to `ref` (optional GPL module, see below)
-   - opts: `-cost XX` (nmi [default], mi, ecc, ncc, ls) `-sep` `-fwhm` `-dither 0|1` `-coarse sparse|downsample` `-verbose 0|1`
-   - default reslices onto the `ref` grid (`-interp trilinear [default]|nearest`, `-fill zero [default]|nan`); `-estimate` instead rewrites only the source sform/qform
- - `spm_deface <tmpl> <mask> [opts]`: SPM analogue of `deface`, registering with spm_coreg (optional GPL module, see below)
-   - opts: same estimate sub-options as `spm_coreg`, plus `-interp`
- - `--dtifit -k <dwi> -r <bvec> -b <bval> -o <base> [-m <mask>] [-xflip 0|1|auto]` : linear diffusion tensor fit (emulates FSL `dtifit`)
-   - writes `<base>_{FA,MD,L1,L2,L3,V1,V2,V3,S0,MO,tensor}`; fit math from AFNI 3dDWItoDT (public domain)
-   - `-xflip auto` (default) flips the bvec X component when the spatial transform determinant is positive, matching FSL
- - `--qc <t1> --seg <seg> --csf <i[,j..]> --wm <i[,j..]> [--erode 0|1] [--out qc.tsv]` : MRIQC-style anatomical quality metrics from a T1 + integer segmentation
-   - writes a wide TSV (default `qc.tsv`) with CJV, cnr_noair, per-tissue/total SNR, WM2MAX, efc_brain, ICV fractions + mm³ volumes, and per-tissue summary stats
-   - label convention: `0` = non-brain (excluded); `--csf`/`--wm` give disjoint CSF/WM label values, every other non-zero label is GM. Only air-free metrics are computed; this hard-segmentation variant uses unrounded intensities and NumPy-linear percentiles, so it is not numerically interchangeable with MRIQC's soft-PVM summaries. `cnr_noair`/`efc_brain` flag deviations from MRIQC norms
- - `--medic --magnitude <e1> [<e2> ...] --phase <e1> [<e2> ...] --te-ms <t1,t2,...> --total-readout-time <sec> --phase-encoding-direction <i|j|k|i-|j-|k-> --out-prefix <path>` : **MEDIC** multi-echo distortion correction — estimates a B0 field map per frame from multi-echo phase and converts it to an EPI displacement map you can apply with `-unwarp`
-   - writes `<prefix>_fieldmaps_native` (Hz, distorted grid), `<prefix>_fieldmaps` (Hz, undistorted grid) and `<prefix>_displacementmaps` (mm), all float32. At least two echoes are required; per frame it removes the MCPC-3D-S phase offset, unwraps with ROMEO, and fits a magnitude-weighted field map, then applies a temporal 2π consistency correction and a low-rank truncation across frames
-   - give `--phase-encoding-direction` the BIDS value including its sign (`j-`, not `j`): `--medic` **honors** the `-` suffix — it drives the inversion and flips the sign of the displacement map. Note the contrast with `-unwarp`, which **ignores** the suffix because the sign is already stored in the map it reads
-   - options: `--rank <N>` (low-rank truncation of the field-map series, default 10; `0` disables) `--temporal-correction <0|1>` `--phase-offset <mcpc|none>` `--noise-frames <N>` (drop N trailing frames from the outputs) `--weights <romeo|romeo2|romeo3|romeo4|romeo6>` (default `romeo4`; governs both the MCPC-3D-S and the multi-echo unwrap) `--mask <file>` (use this mask verbatim for both unwrapping stages, instead of ROMEO's `robustmask` of the first echo) `--save-intermediates` `--n-cpus <N>` `--gz <0|1>`. See also `niimath --medic --help`
-   - `--mask` counts a voxel as inside the brain when its value is **`>= 1`**, not merely non-zero — that is the measured convention of the reference. A fractional probability map is therefore not a mask: threshold it first (`niimath p.nii -thr 0.5 -bin mask.nii`). NaN is treated as outside, and a mask with no voxel `>= 1` is an error rather than an empty result
-   - the whole run is held in RAM by design (a 4D `.nii.gz` cannot be seeked, so nothing is gained by streaming it): the work arrays are `nx·ny·nz × frames × (2·echoes + 3) × 4` bytes and that budget is printed at startup; the peak adds one echo pair of input (they are loaded and released one echo at a time) and one echo pair in transit — measured peak for 170 frames × 2 echoes at 76×76×46 is 1.70 GB single-threaded and 1.89 GB at 8 threads writing uncompressed (the reference tool needs 3.40 GB for the same run). It grows linearly with frames × echoes, so estimate natively and use `-unwarp` where memory is tight (a WebAssembly build has a 4 GiB ceiling)
-   - an optional stdlib-only BIDS wrapper (`medic.py`, in the `medic_bench` repository) discovers multi-echo runs, reads the parameters from their JSON sidecars, and drives `--medic` and `-unwarp` for you
-   - a clean-room emulation developed from the published method and black-box measurement of the reference tool; every convention it implements is recorded in the `medic_bench` repository, which also holds the benchmarks and the patent analysis. **No equivalence with the reference tool is claimed.** `-unwarp` does reproduce it closely — fed the reference's own displacement map it matches the reference's corrected images to nrmse 3.5e-5 — but `--medic` does **not** match end to end: given the same mask its native field map agrees to 0.0027 Hz at the 99th percentile, while the reference's brain-mask construction, its iteration-limited field inversion and a residual in its low-rank filtering are deliberately not reproduced. Supply the same mask to both with `--mask` when you want a like-for-like comparison
-   - please cite Van et al. 2026, *Imaging Neuroscience* 4, [doi:10.1162/IMAG.a.1262](https://doi.org/10.1162/IMAG.a.1262), and the ROMEO reference above for the unwrapping
- - `--compare <ref>`       : report if images are identical, terminates without saving new image
- - `--bitmap -a name.png`  : mimic fsl slicer (see [niimath-bitmap](https://github.com/rordenlab/niimath-bitmap))
- - `filename.nii`          : mimic fslhd (can also export to a txt file: 'niimath T1.nii 2> T1.txt') report header and terminate without saving new image
+- `FSLOUTPUTTYPE` sets the output file format, as in [FSL](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslEnvironmentVariables). On Unix, run `export FSLOUTPUTTYPE=NIFTI_GZ`, `export FSLOUTPUTTYPE=NIFTI` or `export FSLOUTPUTTYPE=NIFTI_ZST` (zstd compressed; requires zstd support) on the command line or in your profile. On Windows, use `set` instead of `export`.
+- `AFNI_COMPRESSOR=PIGZ` compresses `.gz` output with the parallel [pigz](https://github.com/madler/pigz) program. If the variable is not set, or has any other value, compression is single threaded.
 
-## Identical Versus Equivalent Results
+To set the number of OpenMP threads, put `-p <threads>` before the input, or set `OMP_NUM_THREADS`:
 
-This project is designed to provide equivalent results to fslmaths. In most cases, the results are identical, virtually all others are equivalent. The results are not always identical as computations are conducted using floating point representations, where the precise order of instructions can generate small rounding differences. As [Kernighan and Plauger]( https://www.amazon.com/Elements-Programming-Style-Brian-Kernighan/dp/0070341990) note `Floating point numbers are like piles of sand; every time you move one you lose a little sand and pick up a little dirt.` Raw brain imaging data is typically stored as 16-bit integers (and the signal-to-noise is typically a fraction of this dynamic range), whereas niimath uses single (32-bit) or double (64-bit) floating point representations. Therefore, while niimath may generate results that are not identical, the results are intended to be always comparable. For further information on floating point accuracy, suggested readings include [here](https://introcs.cs.princeton.edu/java/91float/) and [here](http://www.freshsources.com/page1/page7/files/Sand-1.pdf).
+```
+niimath -p 4 in.nii -add 1 out.nii
+export OMP_NUM_THREADS=4
+```
 
-This project includes the `--compare` argument that allows you to directly the results of niimath and fslmath. A validation repository is also available, which runs hundreds of commands to detect the quality of the output. The validation repository includes two scripts. The `batch.sh` script tests functions that generate identical results. The `close.sh` script conducts tests on functions that provide equivalent but not identical results. For example, for tensor decomposition the vector [1 0 0] is the functionally identical to [-1 0 0] as for fiber tracking the fiber direction ignores vector polarity. When a difference is detected by the `--compare` function, a report is generated allowing the user to determine the equivalence of solutions:
+To read from standard input or write to standard output, use the filename `-`. Both streams must be uncompressed single-file NIfTI-1 images. Only one image can be piped at a time. See the [library README](https://github.com/rordenlab/niimath/blob/master/library/README.md) for Python examples.
+
+```
+niimath - -add 1 -
+```
+
+## Operations not in fslmaths
+
+This section lists the operations that niimath adds. Run `niimath` with no arguments for the fslmaths-compatible operations.
+
+### Simple operations
+
+| Operation | Description |
+|---|---|
+| `-bandpass <hp> <lp> <tr>` | Butterworth filter. `hp` and `lp` are the highpass and lowpass frequencies in Hz. `tr` is in seconds. Zero-phase, 2 × 2nd order filtfilt. |
+| `-bptfm <hp> <lp>` | Same as `-bptf` but does not remove the mean. Emulates fslmaths before 5.0.7. |
+| `-bwlabel <conn>` | Connected component labeling of non-zero voxels. `conn` sets the neighbors: 6, 18 or 26. |
+| `-c2h` | Reverse the `-h2c` transform. |
+| `-ceil` | Round voxels up to the nearest integer. |
+| `-close <thr> <dx1> <dx2>` | Morphological close. Binarizes at `thr`, dilates by `dx1`, erodes by `dx2`. Fills bubbles with `thr`. |
+| `-comply <nx> <ny> <nz> <dx> <dy> <dz> <f_high> <isLinear>` | Conform to axial slices with `nx × ny × nz` voxels of `dx × dy × dz` mm. `f_high` clamps bright voxels (0.98 clamps the top 2%). `isLinear` selects linear (1) or nearest-neighbor (0) interpolation. |
+| `-conform` | Reslice to 1 mm voxels in the coronal slice direction with 256³ voxels. |
+| `-crop <tmin> <tsize>` | Keep `tsize` volumes starting at volume `tmin`. Volume numbers start at 0, not 1. A `tsize` of -1 means the full range. |
+| `-dehaze <mode>` | Set dark voxels to zero. `mode` is 1 to 5. A higher mode keeps more voxels. |
+| `-demean` | Remove the average signal across volumes. Requires 4D input. |
+| `-detrend` | Remove the linear trend and the mean. |
+| `-dilate <thr> <dx>` | Morphological dilate. Binarizes at `thr` and grows up to distance `dx`. |
+| `-dog <sPos> <sNeg>` | Difference of Gaussians with zero-crossing edges. Sigmas are in mm. |
+| `-dogr <sPos> <sNeg>` | As `-dog`, without zero crossing (raw data, not binarized). |
+| `-dogx <sPos> <sNeg>` | As `-dog`, with zero crossing in 2D sagittal slices. |
+| `-dogy <sPos> <sNeg>` | As `-dog`, with zero crossing in 2D coronal slices. |
+| `-dogz <sPos> <sNeg>` | As `-dog`, with zero crossing in 2D axial slices. |
+| `-edginess` | Scalar field of local vector contrast: the Euclidean distance between each voxel and its neighbors. Useful for RGB or multi-channel data. |
+| `-edt` | Euclidean distance transform (distance field). Assumes isotropic voxels. |
+| `-erode <thr> <dx>` | Morphological erode. Binarizes at `thr` and shrinks within distance `dx`. |
+| `-floor` | Round voxels down to the nearest integer. |
+| `-gz <mode>` | NIfTI gzip mode: 0 = uncompressed, 1 = compressed, any other value = use the FSL environment. Default -1. |
+| `-h2c` | Convert CT scans from Hounsfield to Cormack units, which emphasize soft tissue contrast. |
+| `-mod` | Fractional modulus remainder. Same as `-rem`, but keeps fractions. |
+| `-otsu <mode>` | Binarize with Otsu's method. `mode` is 1 to 5. A higher mode keeps more bright voxels. |
+| `-p <threads>` | Set the maximum number of parallel threads. 0 uses all available threads. |
+| `-power <exponent>` | Raise each voxel to the given exponent. |
+| `-qform <code>` | Set `qform_code`. |
+| `-ras` | Reorder and flip dimensions to RAS orientation. |
+| `-reslice <target>` | Reslice to match image `target` with linear interpolation. |
+| `-reslice_nn <target>` | Reslice to match image `target` with nearest-neighbor interpolation. |
+| `-reslice_mask <mask>` | Reslice `mask` onto the current image with nearest neighbor. Voxels where the mask is ≤ 0 are set to the minimum intensity. |
+| `-resize <X> <Y> <Z> <m>` | Grow (> 1) or shrink (< 1) the image. Method `m`: 0 = nearest, 1 = linear, 2 = spline, 3 = Lanczos, 4 = Mitchell. |
+| `-robustfov [mm]` | Crop to a robust field of view (default 170 mm) from the top of the head down. Removes the lower head and neck. Emulates FSL `robustfov`. Adjusts the dimensions and the sform/qform. |
+| `-round` | Round voxels to the nearest integer. |
+| `-scale01` | Rescale intensities linearly to the range 0 to 1 with the global minimum and maximum. |
+| `-sedt` | Signed Euclidean distance transform (distance field). Assumes isotropic voxels. |
+| `-sform <code>` | Set `sform_code`. |
+| `-sobel` | Fast edge detection. |
+| `-sobel_binary` | Sobel edge detection with a binary result. |
+| `-tensor_2lower` | Convert an FSL-style upper-triangle tensor image to the NIfTI-standard lower-triangle order. |
+| `-tensor_2upper` | Convert a NIfTI-standard lower-triangle tensor image to the FSL-style upper-triangle order. |
+| `-tensor_decomp_lower` | As `-tensor_decomp`, but the input stores the lower triangle (AFNI, ANTS and Camino convention). |
+| `-trunc` | Remove the fractional part of each voxel and return the integer value. |
+| `-unifize [-GM]` | Bias field correction, adapted from AFNI 3dUnifize. The optional `-GM` also scales gray-matter intensity toward a common target. |
+| `-unsharp <sigma> <scl>` | Edge-enhancing unsharp mask. `sigma` is in mm, not voxels (1 is typical). `scl` is the amount (0.5 medium, 1.0 heavy). |
+
+### `-allineate <base> [opts]`
+
+Affine registration of the current image to `base`, from AFNI 3dAllineate. The output is the registered image on the `base` grid.
+
+| Option | Values | Description |
+|---|---|---|
+| `-cost XX` | `fast`, `fastx` (default), `fasthel`, `fastcr`, `hel`, `nmi`, `lpc`, `lpa`, `ls` | Cost function and engine. See the engines below. The last `-cost` wins. |
+| `-cmass`, `-nocmass` | | Initialization. See the engines below. |
+| `-source_automask` | | Use with `lpc` or `lpa`. |
+| `-warp XX` | `sho`, `shr`, `srs`, `aff` (default) | Transform type. |
+| `-interp XX` | `NN`, `linear` (default), `cubic` | Interpolation during matching. |
+| `-final XX` | `NN`, `linear`, `cubic` (default) | Output interpolation. `-nearest`, `-linear` and `-cubic` are shortcuts. |
+| `-fill XX` | `auto` (default), `zero`, `nan` | Fill for output voxels outside the source field of view. `auto` fills with 0, or with the darkest source voxel if that voxel is negative (CT/Hounsfield air is about -1000, so out-of-FOV voxels read as air, not soft tissue). `zero` is always 0 and is byte-identical to the historical behavior for positive-only MRI. `nan` fills with NaN. |
+| `-master <grid>` | image | Estimate at the base resolution, but reslice the result onto `<grid>`. `<grid>` must share the base world frame (for example a higher-resolution template). |
+| `-savemat out.json` | | Save the fitted world-space `fixed_to_moving` affine and its inverse as self-describing JSON. |
+| `-applymat in.json` | | Reslice the moving image onto `base` with a saved affine. Does no registration. Exclusive with the registration and seed options. Use `-nearest` for label or atlas volumes. |
+| `-com` | | Seed: reset the origin to the brightness center of mass. |
+| `-sym`, `-symd`, `-symb` | | Seed: fold a midsagittal-plane correction into the header. `-symd` de-obliques the frame first. `-symb` auto-competes both. |
+| `-nosagseed` | | Disable the in-MSP rigid seed that `-sym` runs by default. |
+| `-zoom` | | Relax the scale range for abnormal-size subjects (for example an infant against an adult template). Needs an ordinary cost, not a fast one. |
+| `-weight <img>` | image | Graded base-space weight in the style of AFNI 3dAllineate. See the weights below. |
+
+Engines:
+
+- A bare `-allineate`, `-cost fast` and `-cost fastx` select the adaptive clean-room fast engine. It is inspired by SPM and FLIRT, multiresolution, and typically several times faster than the ordinary engine. On a whole-head base it fits HEL and correlation-ratio coarse candidates independently, selects by HEL dependence × overlap, and continues once through the finer HEL stages. A hard-zeroed (skull-stripped) base activates the deeper rigid-HEL, scale-bracketed-HEL and CR-seeded multi-start, with fine-level arbitration before the final affine polish.
+- `-cost fasthel` forces the HEL-only fast trajectory. `-cost fastcr` forces correlation ratio only.
+- `-cost hel`, `nmi`, `lpc`, `lpa` and `ls` select the ordinary AFNI-style engine.
+- The fast engine runs a fixed schedule with internal sampling, so it rejects `-warp`, `-interp`, `-source_automask`, `-dark_automask` and `-zoom`. Use an ordinary cost for those. The `-com`, `-sym`, `-symd` and `-symb` seeds work with every cost. `-final`, `-master` and `-savemat` are honored.
+- With the fast engine, the default and `-cmass` choose between the supplied affine and a center-of-mass recentered start by dependence × overlap. `-com` forces the center of mass. `-nocmass` forces the supplied affine.
+
+Weights (`-weight <img>`):
+
+- `<img>` is a 3D image in base space. Its dimensions and world frame must match `base`.
+- Values are normalized to `[0, 1]` (divided by the maximum) and applied per base voxel. A voxel weighted 0 is excluded. A voxel near 1 dominates. The weight is graded. It is not an exclusion mask.
+- Keep the head outside the region of interest attenuated but nonzero. If the whole exterior is zero, the global scale is underdetermined and the cross-modal fit collapses into the scalp. An AFNI-style whole-head weight anchors the absolute size.
+- Both engines honor the weight. The ordinary engine uses it in place of its manufactured autoweight. The fast engine applies it only at the finest 2 mm stage, so coarse capture and global-scale selection stay whole-head.
+- niimath rejects `-weight` with stdin (`-`), with `-applymat`, and when the weight has no positive voxel over the fixed foreground.
+- If the default fast engine fails and niimath falls back to the ordinary Hellinger engine, the fallback honors the weight. An explicit fast selector never switches engines.
+
+Constraints:
+
+- A 4D moving image registers its first volume only, equivalent to `-crop 0 1`, with a warning. Use `-Tmean` or `-crop` first to choose a volume.
+- Skull stripping is `-deface` with a brain mask. To crop the field of view first, chain `-robustfov` before `-allineate`. Together these make niimath a superset of the standalone `allineate` registration tool.
+
+### `-deface <tmpl> <mask> [opts]`
+
+Removes voxels with a template-space mask. niimath registers the input to `tmpl` (affine), inverts the transform, warps `mask` onto the input's native grid, and sets the voxels where the warped mask is below 0.5 to the image's finite minimum (about 0 for typical MRI). The input itself is never resampled.
+
+Arguments:
+
+- `tmpl`: the template image.
+- `mask`: a mask in `tmpl` space. A value ≥ 0.5 keeps the voxel. A value < 0.5 removes it. The mask decides what is removed: a brain mask keeps the brain (skull stripping), a face mask removes the face (defacing).
+
+Options:
+
+- `-cost XX`: `fast`, `fastx` (default), `fasthel`, `fastcr`, `hel`, `nmi`, `lpc`, `lpa` or `ls`. The engines are the same as for `-allineate`. The fast engine is the default. `-cost hel` selects the ordinary AFNI-style engine.
+- `-cmass`, `-nocmass`: initialization tuning.
+- `-final XX`, `-nearest`, `-linear`, `-cubic`: output interpolation. Default `linear`.
+
+Constraints:
+
+- The input must be 3D. A 4D or multi-volume input is rejected.
+- The fast engine cannot honor `-warp`, `-interp`, `-source_automask` or `-dark_automask`. Use `-cost hel` for those.
+- The `-allineate` workflow options `-savemat`, `-applymat`, `-com`, `-sym`, `-symd`, `-symb`, `-nosagseed`, `-zoom`, `-master`, `-fill` and `-weight` are rejected. The fill stays the image minimum.
+- The former `-skullstrip <tmpl> <mask>` command was removed. It ran the identical operation. Replace `-skullstrip` with `-deface` and supply your brain mask. The result is unchanged.
+
+### `-reface <tmpl> <shell> <weight> [opts]`
+
+Anonymizes a head image by face replacement. Emulates AFNI `afni_refacer2 -mode_reface`. niimath registers the subject to `tmpl`, back-projects the signed template-space `shell` onto the original subject grid, and composites an artificial face. The output stays on the subject grid.
+
+Arguments:
+
+- `tmpl`: the template image.
+- `shell`: the signed face-replacement shell in `tmpl` space. Where the shell is > 0, the voxel is replaced by the shell scaled by a brightness-match factor. Where it is 0, the subject is kept. Where it is < 0, the voxel is set to zero. An edge blend is applied inside the replaced region.
+- `weight`: required. A registration weight in `tmpl` space, as for `-allineate -weight`.
+
+Options: `-cost XX`, as for `-deface`. Both engines work. The shell back-projection is always nearest neighbor, so `-final` does not apply.
+
+Constraints:
+
+- The command fails closed for privacy. If less than 10% of the shell mapped into the subject field of view, which indicates a registration failure, niimath refuses to write the image and returns an error.
+- Check the output visually.
+
+### `-qwarp <base>`
+
+Nonlinear (deformable) registration to `base`. An attributed port of AFNI `3dQwarp -blur 0 3`. The output is the warped image on the `base` grid. Further operations may follow.
+
+Constraints:
+
+- `-qwarp` takes one argument and has no sub-options.
+- The input must already be unifized, skull-stripped, affine-aligned, and on the `base` grid (same dimensions and world frame).
+- Built only with `QWARP=1`. It is off by default because it is memory and CPU heavy and impractically slow in WebAssembly. It requires the allineate engine, so it is unavailable in an `AL=0` build.
+
+### `-romeo <mag|none> [opts]`
+
+ROMEO phase unwrapping. A faithful MIT-licensed C port of [ROMEO.jl](https://github.com/korbinian90/ROMEO.jl) and the [MriResearchTools.jl](https://github.com/korbinian90/MriResearchTools.jl) helpers that its command-line app uses. The current image is the wrapped phase, 3D or 4D with echoes on dimension 4. Further operations may follow.
+
+Arguments:
+
+- `mag`: the magnitude image. This positional argument is required. Pass the literal `none` to unwrap without a magnitude.
+
+| Option | Description |
+|---|---|
+| `-t <TEs>` | Echo times in ms: `16.8`, `16.8,38.56`, `'[16.8,38.56]'` or `epi [te]`. Quote the bracket form for the shell. Required for multi-echo input, optional for a single echo. |
+| `-k <spec>` | Mask: `nomask`, `robustmask` (default), `qualitymask [thr]` (default threshold 0.1), or a mask file. |
+| `-w <spec>` | Weights: `romeo` (default), `romeo2`, `romeo3`, `romeo4`, `romeo6`, or up to 6 bits such as `1010`. A bare `romeo` resolves to `romeo3` with a magnitude and `romeo4` without one. |
+| `-template <n>` | Echo to unwrap spatially (default 1). |
+| `-i` | Individual (not temporal) unwrapping. |
+| `-temporal-uncertain-unwrapping [x]` | Re-unwrap low-quality voxels spatially. 0.5 when the flag is bare, off otherwise. |
+| `-g` | Correct the global n2π offset. |
+| `-q` | Write `<out>_quality`. |
+| `-Q` | Write `<out>_quality_1..6`. |
+| `-B [name]` | Also write a B0 field map in Hz: `<out>_B0` and `<out>_B0_snr`. Needs `-t`. `[name]` replaces the B0 stem. |
+| `-B0-phase-weighting <mode>` | `phase_snr` (default), `phase_var`, `average`, `TEs`, `mag` or `simulated_mag`. |
+| `-no-phase-rescale` | Do not rescale the phase. `-no-rescale` is an alias. |
+| `-no-mask-out` | Do not write `<out>_mask`. |
+| `-v` | Verbose. |
+
+Outputs:
+
+- Side outputs use `nifti_save` postfixes on the output name: `<out>_mask` (only when a mask was computed; `-k nomask` writes none), `<out>_quality` (`-q`), `<out>_quality_1..6` (`-Q`; a map that is uniformly 1.0 in the interior is skipped, as upstream), and `<out>_B0` and `<out>_B0_snr` (`-B`).
+- Side outputs honor `FSLOUTPUTTYPE`. They honor `-gz` and `-p` only when those precede `-romeo`, because the side outputs are written during the operation. A later `-gz` reaches only the main output.
+
+Constraints:
+
+- The phase is rescaled to `[-π, π]` as in `readphase`, unless `-no-phase-rescale` is given. The rescale re-reads the unscaled stored values, so `-romeo` must be the first computational operation when rescaling is active.
+- `-B` computes B0 without MCPC-3D-S phase-offset correction, which ROMEO's own multi-echo `-B` enables silently. The maps correspond to `romeo --compute-B0 --phase-offset-correction off`. niimath says so on stderr. Without a magnitude, ROMEO's SNR map collapses to one value, because the substituted `exp(-TE/20)` decay does not depend on the voxel. niimath writes that constant across the working grid.
+- Not yet ported, and rejected with a specific message: `-u`, `-e`, `-threshold`, `-w bestpath`, `-max-seeds > 1`, `-merge-regions`, `-correct-regions`, `-wrap-addition != 0` and `-fix-ge-phase`. MCPC-3D-S phase-offset correction and multi-channel (5D) input are out of scope.
+- Enabled by default. `ROMEO=0 make` or `-DENABLE_ROMEO=OFF` omits it.
+
+Citation: Dymerska, B. et al. 2020, *Magnetic Resonance in Medicine*, [doi:10.1002/mrm.28563](https://doi.org/10.1002/mrm.28563).
+
+### `-unwarp <map> <axis>`
+
+EPI distortion correction. Resamples the current image through a scalar displacement map in millimeters, as written by `--medic`. Further operations may follow.
+
+Arguments:
+
+- `map`: a 3D map (applied to every frame) or a 4D map with the same frame count as the input. It must share the input's dimensions and world transform.
+- `axis`: `i`, `j` or `k` (or `x`, `y`, `z`). A trailing `-` is accepted and ignored, because the sign is already stored in the map and a second negation would double-correct. `--medic --phase-encoding-direction` is the opposite: it honors the suffix. Pass the full BIDS value there.
+
+Method: an unnormalized Lanczos-5 windowed sinc, applied separably in 3D, with zero fill outside the field of view and no Jacobian intensity modulation. This matches the measured behavior of the reference implementation. See the `medic_bench` repository.
+
+Enabled by default with `--medic`. `MEDIC=0 make` or `-DENABLE_MEDIC=OFF` omits it.
+
+### `-moco [-1Dfile <path.1D>]`
+
+Rigid-body motion correction. Registers every volume of a 4D series onto volume 0 and replaces the image with the corrected series. A clean-room BSD-2 implementation of the method of Cox & Jesmanowicz (*Magnetic Resonance in Medicine* 42:1014-1018, 1999), the algorithm behind AFNI `3dvolreg`. Further operations may follow.
+
+```
+niimath bold -moco out
+niimath bold -moco -1Dfile out.1D out
+```
+
+Options:
+
+- `-1Dfile <path.1D>`: also write the six motion parameters per volume. The filename must end in `.1D`. The file is compatible with AFNI's `-1Dfile`: six columns `roll pitch yaw dS dL dP`, one row per volume. Rotations are in degrees counter-clockwise about the I-S, R-L and A-P axes. Shifts are in mm toward Superior, Left and Posterior. The values record the correction that was applied, not the estimated motion. Row 0 is all zeros, because the base registers to itself.
+
+Constraints:
+
+- The input must be 4D with more than one volume.
+- Correction runs in float32, so `-dt double` is rejected.
+- Enabled by default on every platform, including WebAssembly. `MOCO=0 make` or `-DENABLE_MOCO=OFF` omits it.
+
+### `-stc --slicetiming <t0,t1,...|@file> [-tzero <sec>]`
+
+Slice-time correction. Shifts every voxel time series of a 4D series so that all slices share one temporal origin. A clean-room BSD-2 implementation of the default Fourier method (detrend, interpolate, retrend) of AFNI `3dTshift`, whose GPL-2 source was used only as a black-box oracle. Further operations may follow.
+
+```
+niimath bold -stc --slicetiming @times.1D out
+```
+
+Arguments:
+
+- `--slicetiming`: required, case-sensitive, and must come first. It takes one comma-separated list of slice acquisition times in seconds, or an AFNI-style `@file` (whitespace- or comma-separated; `#` starts a comment). Supply exactly one value per slice along storage axis `k`, in slice-index order. A count that does not match `nz` is an error, not a silently truncated list.
+- `-tzero <sec>`: the common time point. Default: the arithmetic mean of the supplied times. It must lie within their `[min, max]`.
+
+Output: only `toffset` changes in the header, to the common time point in the header's own time units. Geometry, TR and the spatial transforms are untouched.
+
+Constraints:
+
+- The input must be a scalar 4D image with at least 5 volumes, a finite positive `pixdim[4]`, and a usable temporal unit in `xyzt_units` (seconds, milliseconds or microseconds). niimath does not assume seconds.
+- Correction runs in float32, so `-dt double` is rejected.
+- This version corrects along storage axis `k` only.
+- Enabled by default on every platform, including WebAssembly. `STC=0 make` or `-DENABLE_STC=OFF` omits it.
+
+BIDS helper: `test/stc_slicetiming.py` (standard library only) reads a BIDS sidecar and prints the `--slicetiming` argument. It honors `SliceEncodingDirection` (`k` passes through, `k-` is reversed into slice-index order, `i` and `j` are rejected) and stops with an error if the sidecar's `RepetitionTime` disagrees with the unit-normalized header TR:
+
+```
+niimath bold.nii.gz -stc --slicetiming "$(python3 test/stc_slicetiming.py bold.nii.gz)" out.nii.gz
+```
+
+### `-spm_coreg <ref> [opts]`
+
+SPM rigid-body coregistration of the current image to `ref`. Requires the [optional GPL module](#optional-gpl-module).
+
+Options:
+
+- `-cost XX`: `nmi` (default), `mi`, `ecc`, `ncc` or `ls`.
+- `-sep`, `-fwhm`, `-dither 0|1`, `-coarse sparse|downsample`, `-verbose 0|1`.
+- `-interp trilinear|nearest` (default `trilinear`) and `-fill zero|nan` (default `zero`) control the reslicing onto the `ref` grid.
+- `-estimate`: rewrite only the source sform/qform instead of reslicing.
+
+### `-spm_deface <tmpl> <mask> [opts]`
+
+The SPM analog of `-deface`. Registers with `-spm_coreg`. Requires the [optional GPL module](#optional-gpl-module). Options: the same estimate options as `-spm_coreg`, plus `-interp`.
+
+### `-mesh [opts] <output>`
+
+Converts the current image to a triangulated mesh. The output filename extension selects the mesh format. See [Creating meshes](#creating-meshes) for examples.
+
+| Option | Description |
+|---|---|
+| `-i <isovalue>` | Isosurface: `d` (dark), `m` (medium), `b` (bright) or a number. The `d`, `m` and `b` values use Otsu's method. Default: `m`. |
+| `-a <atlasFile>` | Mesh each region of an atlas. |
+| `-b <fillBubbles>` | Fill bubbles. |
+| `-l <onlyLargest>` | Keep only the largest object. |
+| `-o <originalMC>` | Use the original marching cubes. |
+| `-q <quality>` | Quality. |
+| `-s <postSmooth>` | Smooth after meshing. |
+| `-r <reduceFraction>` | Reduce the triangle count to this fraction. |
+| `-v <verbose>` | Verbose. |
+| `-hollow <threshold> <thickness>` | Hollow out a mesh. |
+
+### `-bitmap [overlay] [opts] <output.png>`
+
+Creates a PNG image from the current volume, with an optional overlay volume. The arguments are inspired by FSL `slicer`. See [niimath-bitmap](https://github.com/rordenlab/niimath-bitmap) for examples and documentation.
+
+Slice selection. Values from 0.0 to 1.0 are fractional positions. Negative values are absolute slice numbers.
+
+| Option | Description |
+|---|---|
+| `-a` | Axial, coronal and sagittal slices at the midpoint (0.5). |
+| `-m` | Mosaic view with slices at 0.25, 0.5 and 0.75 for each axis. |
+| `-o` | Select the largest plane orientation automatically. |
+| `-x <val1> [val2...]` | Sagittal slices at the given positions. |
+| `-y <val1> [val2...]` | Coronal slices at the given positions. |
+| `-z <val1> [val2...]` | Axial slices at the given positions. |
+| `-X`, `-Y`, `-Z <vals>` | As `-x`, `-y`, `-z`, but draw crosshairs from the other axes. |
+| `-r` | Insert a row separator between slice groups. |
+
+Display options:
+
+| Option | Description |
+|---|---|
+| `-f [0\|1]` | Flip left-right. 0 = neurological, 1 = radiological (default). |
+| `-u [0\|1]` | Show L/R labels (default 1). |
+| `-n [0\|1]` | Interpolation. 0 = nearest neighbor, 1 = linear. |
+| `-s <scale>` | Scale factor for the output image size. |
+
+Color and intensity:
+
+| Option | Description |
+|---|---|
+| `-t <min> <max>` | Intensity range for the base image. |
+| `-T <min> <max>` | Intensity range for the overlay image. |
+| `-c <lut> [alpha]` | Base image color lookup table. |
+| `-c <R> <G> <B> <A>` | Base image RGBA tint (values 0.0 to 1.0). |
+| `-C <lut> [alpha]` | Overlay color lookup table. |
+| `-C <R> <G> <B> <A>` | Overlay RGBA color (values 0.0 to 1.0). |
+| `-b <R> <G> <B> <A>` | Background RGBA color (values 0.0 to 1.0). |
+| `-N [0\|1]` | Use a negative colormap for the overlay (blue-green for negative values). |
+| `-e` | Apply edge detection to the overlay. |
+
+Color lookup tables: `gray`, `red`, `green`, `blue`, `cyan`, `yellow`, `bluegreen`, `redyellow`, `viridis`, `inferno`, `magma`, `plasma`.
+
+```
+niimath T1.nii -bitmap -a output.png
+niimath T1.nii -bitmap fmri.nii -C red 0.5 -z 0.5 overlay.png
+niimath T1.nii -bitmap -m -c viridis mosaic.png
+```
+
+### `--dtifit -k <dwi> -r <bvec> -b <bval> -o <base> [-m <mask>] [-xflip 0|1|auto]`
+
+Linear diffusion tensor fit. Emulates FSL `dtifit`. This is a self-contained command with its own arguments. The fit math comes from AFNI 3dDWItoDT (public domain).
+
+Outputs: `<base>_{FA,MD,L1,L2,L3,V1,V2,V3,S0,MO,tensor}`.
+
+Options:
+
+- `-m <mask>`: restrict the fit to a mask.
+- `-xflip auto` (default) flips the bvec X component when the spatial transform determinant is positive, which matches FSL. `0` never flips. `1` always flips.
+
+### `--qc <t1> --seg <seg> --csf <i[,j..]> --wm <i[,j..]> [--erode 0|1] [--out qc.tsv]`
+
+MRIQC-style anatomical quality metrics from a T1 image and an integer segmentation. This is a self-contained command with its own arguments.
+
+Output: a wide TSV (default `qc.tsv`) with CJV, cnr_noair, per-tissue and total SNR, WM2MAX, efc_brain, ICV fractions with mm³ volumes, and per-tissue summary statistics.
+
+Labels: `0` is non-brain and is excluded. `--csf` and `--wm` give disjoint sets of CSF and WM label values. Every other non-zero label is GM.
+
+Constraints: only air-free metrics are computed. This hard-segmentation variant uses unrounded intensities and NumPy-linear percentiles, so its values are not numerically interchangeable with MRIQC's soft partial-volume summaries. The names `cnr_noair` and `efc_brain` flag their deviation from the MRIQC norms.
+
+### `--medic --magnitude <e1> [<e2> ...] --phase <e1> [<e2> ...] --te-ms <t1,t2,...> --total-readout-time <sec> --phase-encoding-direction <i|j|k|i-|j-|k-> --out-prefix <path> [options]`
+
+MEDIC multi-echo distortion correction. Estimates a B0 field map per frame from multi-echo phase and converts it to an EPI displacement map that `-unwarp` can apply. This is a self-contained command with its own arguments. Run `niimath --medic --help` for the full option list.
+
+Outputs: `<prefix>_fieldmaps_native` (Hz, distorted grid), `<prefix>_fieldmaps` (Hz, undistorted grid) and `<prefix>_displacementmaps` (mm). All are float32.
+
+Method: at least two echoes are required. For each frame, niimath removes the MCPC-3D-S phase offset, unwraps with ROMEO, and fits a magnitude-weighted field map. It then applies a temporal 2π consistency correction and a low-rank truncation across frames.
+
+| Option | Description |
+|---|---|
+| `--rank <N>` | Low-rank truncation of the field-map series. Default 10. `0` disables it. Experimental: rank 10 is what the paper specifies, but the reference tool's own output keeps a broadband residual past component 10 whose origin is unresolved, so this stage is the least reference-faithful part of the pipeline. |
+| `--temporal-correction <0\|1>` | Temporal 2π consistency correction. Default 1. |
+| `--phase-offset <mcpc\|none>` | MCPC-3D-S phase-offset correction. Default `mcpc`. |
+| `--noise-frames <N>` | Drop N trailing frames from the outputs. Default 0. |
+| `--weights <sel>` | ROMEO weight preset: `romeo`, `romeo2`, `romeo3`, `romeo4` (default) or `romeo6`. Governs both the MCPC-3D-S and the multi-echo unwrap. |
+| `--mask <file>` | Use this mask verbatim for both unwrapping stages, instead of ROMEO's `robustmask` of the first echo. See the mask rule below. |
+| `--save-intermediates` | Also write the per-echo unwrapped phase, the masks, and the estimated phase offset when MCPC-3D-S runs. |
+| `--n-cpus <N>` | OpenMP threads. |
+| `--gz <0\|1>` | Output compression. Default: the `FSLOUTPUTTYPE` environment. |
+
+Phase-encoding polarity: give `--phase-encoding-direction` the BIDS value with its sign (`j-`, not `j`). `--medic` honors the `-` suffix. It drives the inversion and flips the sign of the displacement map. `-unwarp` ignores the suffix, because the sign is already stored in the map it reads.
+
+Mask rule: `--mask` counts a voxel as inside the brain when its value is `>= 1`, not merely non-zero. That is the measured convention of the reference tool. A fractional probability map is not a mask. Threshold it first: `niimath p.nii -thr 0.5 -bin mask.nii`. NaN is treated as outside. A mask with no voxel `>= 1` is an error, not an empty result.
+
+Memory: the whole run is held in RAM by design. A 4D `.nii.gz` cannot be seeked, so streaming gains nothing. The work arrays are `nx·ny·nz × frames × (2·echoes + 3) × 4` bytes. niimath prints that budget at startup. The peak adds one echo pair of input (echoes are loaded and released one at a time) and one echo pair in transit. The measured peak for 170 frames × 2 echoes at 76×76×46 is 1.70 GB single-threaded and 1.89 GB at 8 threads writing uncompressed. The reference tool needs 3.40 GB for the same run. Memory grows linearly with frames × echoes. Where memory is tight, estimate natively and apply `-unwarp` separately. A WebAssembly build has a 4 GiB ceiling.
+
+Fidelity: `--medic` is a clean-room emulation developed from the published method and black-box measurement of the reference tool. Every convention it implements is recorded in the `medic_bench` repository, which also holds the benchmarks and the patent analysis. **No equivalence with the reference tool is claimed.** `-unwarp` does reproduce it closely: fed the reference's own displacement map, it matches the reference's corrected images to nrmse 3.5e-5. `--medic` does not match end to end. Given the same mask, its native field map agrees to 0.0027 Hz at the 99th percentile. The reference's brain-mask construction, its iteration-limited field inversion, and a residual in its low-rank filtering are deliberately not reproduced. Supply the same mask to both tools with `--mask` for a like-for-like comparison.
+
+BIDS wrapper: `medic.py` in the `medic_bench` repository (standard library only) discovers multi-echo runs, reads the parameters from their JSON sidecars, and runs `--medic` and `-unwarp` for you.
+
+Citation: Van et al. 2026, *Imaging Neuroscience* 4, [doi:10.1162/IMAG.a.1262](https://doi.org/10.1162/IMAG.a.1262), and the ROMEO reference above for the unwrapping.
+
+### `--compare [<thresh>] <ref>`
+
+Reports whether the current image and `ref` are identical, then exits without saving an image. With `<thresh>`, the exit code is success if the largest difference is less than `thresh`. See [Compatibility with fslmaths](#compatibility-with-fslmaths) for a sample report.
+
+### `niimath <filename.nii>`
+
+With an input file and no other arguments, niimath prints the header, as `fslhd` does, and exits without saving an image. To save the report to a text file, redirect stderr: `niimath T1.nii 2> T1.txt`.
+
+## Creating meshes
+
+niimath converts NIfTI images to meshes for Surfice, Blender, SUMA, FreeSurfer and other tools. The features come from [nii2mesh](https://github.com/neurolabusc/nii2mesh) and are almost identical. The argument order differs, to match fslmaths and niimath. The call `nii2mesh -r 1 bet.nii.gz r100.ply` becomes `niimath bet.nii.gz -mesh -r 1 r100.ply`.
+
+With niimath you can apply voxel operations before you create the mesh, for example the morphological operations `-close`, `-ero` and `-dilM`. To apply a 4 mm Gaussian smooth before meshing:
+
+```
+niimath mni152.nii.gz -s 4 -mesh -i 122 -l 0 -b 1 b1.ply
+```
+
+To create one mesh for each region of an atlas, as described on the [nii2mesh](https://github.com/neurolabusc/nii2mesh) page:
+
+```
+niimath D99_atlas_v2.0_right.nii.gz -mesh -p 0 -s 10 -a D99_v2.0_labels_semicolon.txt ./gii/D99s10roi.gii
+```
+
+Both programs set the isolevel with `-i`. With `-i 128`, the surface encloses the voxels brighter than 128. niimath also accepts `-i d`, `-i m` and `-i b` for dark, medium and bright. These use Otsu's method and usually find pleasing values. If you give no isolevel, nii2mesh uses the midpoint between the darkest and brightest value, while niimath uses the medium Otsu threshold, which is more robust to outliers.
+
+```
+niimath bet.nii.gz -mesh -i 128 Isolevel128.gii
+niimath bet.nii.gz -mesh -i d darkIsolevel.gii
+niimath bet.nii.gz -mesh -i m medIsolevel.gii
+niimath bet.nii.gz -mesh -i b brightIsolevel.gii
+```
+
+## Creating bitmaps
+
+Use `-bitmap` to visualize the result of any chain of operations. Its arguments are inspired by FSL `slicer`, with new features. See the [`-bitmap` reference](#-bitmap-overlay-opts-outputpng) above and the [niimath-bitmap](https://github.com/rordenlab/niimath-bitmap) repository for examples and documentation.
+
+## Compatibility with fslmaths
+
+### Identical versus equivalent results
+
+niimath is designed to give results equivalent to fslmaths. In most cases the results are identical. In almost all other cases they are equivalent. The results are not always identical because both tools compute in floating point, where the precise order of instructions creates small rounding differences. As [Kernighan and Plauger](https://www.amazon.com/Elements-Programming-Style-Brian-Kernighan/dp/0070341990) wrote: `Floating point numbers are like piles of sand; every time you move one you lose a little sand and pick up a little dirt.` Raw brain imaging data are usually stored as 16-bit integers, and the signal-to-noise ratio is usually a fraction of that dynamic range. niimath computes in single (32-bit) or double (64-bit) precision. So niimath may give results that are not identical, but they are intended to be always comparable. For more on floating point accuracy, see [here](https://introcs.cs.princeton.edu/java/91float/) and [here](http://www.freshsources.com/page1/page7/files/Sand-1.pdf).
+
+The `--compare` operation compares the results of niimath and fslmaths directly. A [validation repository](https://github.com/rordenlab/niimath_tests) runs hundreds of commands to check the output. Its `batch.sh` script tests the functions that give identical results. Its `close.sh` script tests the functions that give equivalent but not identical results. For example, in tensor decomposition the vector [1 0 0] is functionally identical to [-1 0 0], because fiber tracking ignores the polarity of the direction. When `--compare` finds a difference, it prints a report so you can judge whether the results are equivalent:
 
 ```
 Images Differ: Correlation r = 1, identical voxels 73%
@@ -231,26 +582,28 @@ Image 2 Descriptives
     86.29 real    41.08 user    23.41 sys
 ```
 
-Some operations do generate known meaningfully different results. These are listed below, with the rationale for the discrepancy provided:
+### Known differences
 
-1. The command "fslmaths inputimg -add 0 outputimg -odt input" can convert a uint8 image float output despite explicit request to retain input type. This occurs if the input image header has a non-unitary scale slope or non-zero intercept. In contrast, niimath retains both the datatype and the intensity scaling parameters.
-2. Different versions of fslmaths perform differently for the pass through "fslmaths in out" which is useful for copying files. Old versions will losslessly save in the input datatype, while fslmaths 6.0 converts the data to float. niimath retains the datatype.
-3. The fslmaths function `-fillh26` will sometimes fill unconnected regions. An example has been provided to the FSL team. niimath provides the correct solution.
-4. The fslmaths `-dilD` function does not do what it claims. It introduces a blurring effect that reduces edge artifacts that plague iterative morphology operations. Unfortunately, this effect is conducted in a consistent order that introduces a spatial shift in signal. In contrast, niimath does the dilation as described. Note there are [better solutions](https://github.com/neurolabusc/niiSmooth) for these functions. The niimath '-edt' operation can also be used for dilation.
-6. The fslmaths `-roc` function works differently than described in the help. It appears to ignore voxels near the edge of an image and generates "given object has non-finite elements" if any dimension is less than 12 voxels. When provided with an external noise file, it generates additional columns in the output file that are not described. It does not seem to precisely detect the desired `AROC-thresh`, but samples at different stepped intervals. niimath attempts to emulate the stepped intervals for reporting, but determines the precise cutoff.
-7. Be aware that fslmaths help suggests `If you apply a Binary operation (one that takes the current image and a new image together), when one is 3D and the other is 4D, the 3D image is cloned temporally to match the temporal dimensions of the 4D image.` This is not the case for -thr or -uthr: if the second item is 4D, only the first volume is used and the output remains 3D. Particularly odd is uthr: `fslmaths 3D -uthr 4D out` will fill input volume 3D with zeros, regardless of mask values.
-8. Perhaps understandably, `fslmaths in1 -rem 0 out` will throw an exception. However, `fslmaths in1 -rem in2 out` will throw an exception if any voxel in the image `in2` is zero. While this seems understandable, niimath provides a description for this error.
-9. The fslmaths function `-rem` returns the **integer** modulus remainder. This replicates the C `%` operator. This may be unexpected, e.g. in Python `2.7 % 2` is 0.7, as is Matlab's `mod(2.7, 2)`, as is standard C `fmod`. niimath clones the fslmaths  behavior, but also includes a new function `-mod` to return the modulus fractional remainder.
-10. Be aware that fslmaths takes account of whether the image has a negative determinant or not (flipping the first dimension). However, fslstats does not do this, so fslstats coordinates are often misleading. For example, consider an image in RAS orientation, where the command `fslstats tfRAS -x` will give coordinates that are incompatible with fslmath's `tfceS` function. niimath attempts to emulate the behavior of fslmaths for the relevant functions (-index -roi, -tfceS).
-11. Neither `-subsamp2` nor `-subsamp2offc` handle anti-aliasing. Be aware that `-subsamp2offc` can exhibit odd edge effects. The problem is simple to describe, for slices in the middle of a volume, and output slice is weighted 50% with the center slice, and 25% for the slice below and the slice above. This makes sense. However, bottom slices (as well as first rows, first columns, last rows, last columns, last slices) the filter weights 75% on the central slice and just 25% on the slice above it. Signal from this 2nd slice is heavily diluted. A better mixture would be 66% edge slice and 33% 2nd slice. This latter solution is used by niimath.
-12. fslmaths 6.0.0..6.0.3 were unable to process files where the string ".nii" appears in a folder name. For example, consider the folder "test.niim", the command `fslmaths ~/test.niim/RAS -add 0 tst` will [generate an exception](https://github.com/FCP-INDI/C-PAC/issues/976). niimath will recognize that this is a folder name and not a file extension and work correctly. niimath helped detect this anomaly and it is an example of how a clone can help provide feedback to the developers of the original project.
-13. The fslmaths function [`-ztop`](https://github.com/rordenlab/niimath/issues/8) fails to clamp extreme values.
+These operations give meaningfully different results. Each item gives the reason:
 
-Finally, it is possible that there are some edge cases where niimath fails to replicate fslmath. This is new software, and many of the operations applied by fslmaths are undocumented. If users detect any problems, they are encouraged to generate a Github issue to report the error.
+1. The command `fslmaths inputimg -add 0 outputimg -odt input` can convert a uint8 image to float output, despite the explicit request to keep the input type. This happens when the header has a non-unitary scale slope or a non-zero intercept. niimath keeps both the datatype and the intensity scaling parameters.
+2. Versions of fslmaths differ for the pass-through `fslmaths in out`, which is useful for copying files. Old versions save losslessly in the input datatype. fslmaths 6.0 converts the data to float. niimath keeps the datatype.
+3. The fslmaths function `-fillh26` sometimes fills unconnected regions. An example was sent to the FSL team. niimath gives the correct solution.
+4. The fslmaths function `-dilD` does not do what it claims. It introduces a blur that reduces the edge artifacts of iterative morphology. The blur runs in a fixed order, so it shifts the signal spatially. niimath does the dilation as described. [Better solutions](https://github.com/neurolabusc/niiSmooth) exist for these functions. The niimath `-edt` operation can also dilate.
+5. The fslmaths function `-roc` works differently than its help describes. It appears to ignore voxels near the image edge, and it reports "given object has non-finite elements" if any dimension is less than 12 voxels. With an external noise file, it adds undocumented columns to the output file. It does not detect the requested `AROC-thresh` precisely, but samples at stepped intervals. niimath emulates the stepped intervals for reporting, but finds the precise cutoff.
+6. The fslmaths help says: `If you apply a Binary operation (one that takes the current image and a new image together), when one is 3D and the other is 4D, the 3D image is cloned temporally to match the temporal dimensions of the 4D image.` This is not the case for `-thr` and `-uthr`. If the second image is 4D, only its first volume is used and the output stays 3D. `-uthr` is odd: `fslmaths 3D -uthr 4D out` fills the 3D input with zeros regardless of the mask values.
+7. `fslmaths in1 -rem 0 out` throws an exception, which is understandable. `fslmaths in1 -rem in2 out` also throws an exception if any voxel in `in2` is zero. niimath describes this error.
+8. The fslmaths function `-rem` returns the **integer** modulus remainder, like the C `%` operator. This may be unexpected: in Python `2.7 % 2` is 0.7, as in Matlab's `mod(2.7, 2)` and the standard C `fmod`. niimath clones the fslmaths behavior and adds `-mod`, which returns the fractional remainder.
+9. fslmaths accounts for a negative determinant by flipping the first dimension. fslstats does not, so fslstats coordinates are often misleading. For an image in RAS orientation, `fslstats tfRAS -x` gives coordinates that are incompatible with the fslmaths `tfceS` function. niimath emulates fslmaths for the relevant functions (`-index`, `-roi`, `-tfceS`).
+10. Neither `-subsamp2` nor `-subsamp2offc` applies anti-aliasing. `-subsamp2offc` shows odd edge effects. For slices in the middle of a volume, an output slice is weighted 50% from the center slice and 25% each from the slices below and above, which makes sense. At the edges (the first and last slices, rows and columns) the filter weights 75% on the central slice and 25% on the neighbor, so the neighbor's signal is heavily diluted. A better mixture is 66% edge slice and 33% neighbor. niimath uses the latter.
+11. fslmaths 6.0.0 to 6.0.3 cannot process files when the string ".nii" appears in a folder name. For the folder "test.niim", `fslmaths ~/test.niim/RAS -add 0 tst` [throws an exception](https://github.com/FCP-INDI/C-PAC/issues/976). niimath recognizes that this is a folder name, not a file extension, and works. niimath helped detect this anomaly. It is an example of how a clone gives feedback to the original project.
+12. The fslmaths function [`-ztop`](https://github.com/rordenlab/niimath/issues/8) does not clamp extreme values.
 
-## Superior Performance
+Some edge cases may remain where niimath does not replicate fslmaths. This is new software, and many fslmaths operations are undocumented. If you find a problem, open a GitHub issue.
 
-Here are some examples of speed up factors you can expect. The sample T1-weighted and resting state data use the [HCP 3T Imaging Protocol](http://protocols.humanconnectome.org/HCP/3T/imaging-protocols.html) sequences. The tests were run on a laptop with a four core (8 thread, 28w) MacOS laptop:
+## Performance
+
+These speedup factors compare niimath with fslmaths. The T1-weighted and resting-state data use the [HCP 3T Imaging Protocol](http://protocols.humanconnectome.org/HCP/3T/imaging-protocols.html) sequences. The first table is from a macOS laptop with four cores (8 threads, 28 W):
 
 | Command : Seconds (GZ)                                 |  Serial (GZ)  | Parallel (GZ) |
 |--------------------------------------------------------|--------------:|--------------:|
@@ -260,7 +613,7 @@ Here are some examples of speed up factors you can expect. The sample T1-weighte
 |  niimath rest -demean out (same output as above)       | 3.5x (3.0x)   | 4.6x (6.2x)   |
 | fslmaths rest -bptf 77 8.68 out : 998 (1155)           | 2.0x (2.0x)   | 6.8x (6.7x)   |
 
-Here are the same testson a desktop computer with twelve cores (24 threads, Ryzen 3900X):
+The second table is the same tests on a desktop with twelve cores (24 threads, Ryzen 3900X):
 
 | Command : Seconds (GZ)                                 |  Serial (GZ)  | Parallel (GZ) |
 |--------------------------------------------------------|--------------:|--------------:|
@@ -270,51 +623,27 @@ Here are the same testson a desktop computer with twelve cores (24 threads, Ryze
 |  niimath rest -demean out (same output as above)       | 2.6x (2.6x)   | 3.0x (10.8x)  |
 | fslmaths rest -bptf 77 8.68 out : 887 (1019)           | 2.6x (2.5x)   | 23x (23.0x)   |
 
-Gaussian smoothing (`-s`/`-dog`/`unsharp`) uses a contiguous vectorizable kernel in every build (native, WASM, and the shared registration pyramid). Neighborhood mean, minimum, maximum, and erosion filters keep their local gathers but evaluate adjacent interior outputs in SIMD lanes, avoiding the non-finite propagation errors of separable running-sum and deque filters.
-
-## Converting voxelwise images to a triangulated mesh
-
-niimath can convert NIfTI images to meshes, suitable for viewing in Surfice, blender, SUMA, FreeSurfer and other tools. The features are based on [nii2mesh](https://github.com/neurolabusc/nii2mesh) and the features are almost identical. However, the order of arguments is different to match the expectations of fslmaths/niimath. So the call `nii2mesh -r 1 bet.nii.gz r100.ply` becomes `niimath bet.nii.gz -mesh -r 1 r100.ply`. The benefit of niimath is that you can apply voxel-based operations before you create your mesh. This allows you to apply morphological operations (`-close`, `-ero`, `-dilM`). As an example, to apply a 4mm Gaussian smooth before creating a mesh, you could run `./niimath mni152.nii.gz -s 4 -mesh -i 122 -l 0 -b 1 b1.ply`. As described on the [nii2mesh](https://github.com/neurolabusc/nii2mesh) page, you can create independent meshes for each area in an atlas using the command:
-
-```
-niimath D99_atlas_v2.0_right.nii.gz -mesh -p 0 -s 10 -a D99_v2.0_labels_semicolon.txt ./gii/D99s10roi.gii
-```
-Both programs allow you to explicitly set the isolevel using the `-i` value, so `-i 128` we render a surface for voxels brighter than 128. One minor difference between the programs is that niimath allows you also request `dark`, `medium` and `bright` using the `-i d`, `-i m` and `-i b` commands respectively. These use Otsu's method, and typically identify pleasing values. Also, if the user does not specify an isolevel be aware that nii2mesh chooses the middle brightness (the midpoint between the darkest and brightest value) while niimath uses the medium Otsu threshold. The latter is more robust to outliers. Here are examples illustrating this usage:
-
-```
-niimath bet.nii.gz -mesh -i 128 Isolevel128.gii
-niimath bet.nii.gz -mesh -i d darkIsolevel.gii
-niimath bet.nii.gz -mesh -i m medIsolevel.gii
-niimath bet.nii.gz -mesh -i b brightIsolevel.gii
-```
-
-## Creating bitmaps
-
-You can use the `--bitmap` option to visualize the results of any operations. This option has arguments inspired by fsl's slicer, but introduces new features. The [niimath-bitmap](https://github.com/rordenlab/niimath-bitmap) provides examples and documentation.
-
-## WebAssembly
-
-niimath can also be compiled to WebAssembly (Wasm) allowing it to be inserted into web pages and Node.js projects. Here is a [live demo](https://niivue.github.io/niivue-niimath/) with links to source code and instructions.
+Gaussian smoothing (`-s`, `-dog` and `-unsharp`) uses a contiguous vectorizable kernel in every build: native, WASM, and the shared registration pyramid. The neighborhood mean, minimum, maximum and erosion filters keep their local gathers, but they evaluate adjacent interior outputs in SIMD lanes. This avoids the non-finite propagation errors of separable running-sum and deque filters.
 
 ## License
 
-<!-- codespell-ignore-line --> niimath is licensed under the 2-Clause BSD License. Except where noted, the code was written by Chris Rorden in 2020-2022. The code in `tensor.c` was written by Daniel Glen (2004) from the US National Institutes of Health and is not copyrighted (though it is included here with the permission of the author). The FSL team graciously allowed the text strings (help, warning and error messages) to be copied verbatim. The Butterworth Filter Coefficients in `bw.c` are from [Exstrom Labs](http://www.exstrom.com/journal/sigproc/) and the authors provided permission for it to be included in this project under the [LGPL](https://www.gnu.org/licenses/lgpl-3.0.en.html), the file provides additional details. Taylor Hanayik from the FSL group provided pseudo-code for some functions where there is little available documentation. The PolygoniseCube function comes from Cory Bloyd's public domain [Marching Cubes example](http://paulbourke.net/geometry/polygonise/) program described here. The bwlabel.cpp file was written by Jesper Andersson, who has explicitly allowed this to be shared using the BSD 2-Clause license. The [high performance](https://github.com/gaspardpetit/base64) base64.cpp was written by Jouni Malinen and is distributed under the BSD license. The mesh simplification was written by [Sven Forstmann](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification) and distributed under the MIT license. It was ported from C++ to C by Chris Rorden.  The [radixsort.c](https://github.com/bitshifter/radixsort) was written by Cameron Hart (2014) using the zlib license.
+<!-- codespell-ignore-line --> niimath is licensed under the 2-Clause BSD License. Except where noted, Chris Rorden wrote the code in 2020-2022. Daniel Glen of the US National Institutes of Health wrote the code in `tensor.c` (2004). It is not copyrighted, and it is included here with the author's permission. The FSL team allowed the text strings (help, warning and error messages) to be copied verbatim. The Butterworth filter coefficients in `bw.c` come from [Exstrom Labs](http://www.exstrom.com/journal/sigproc/). The authors gave permission to include them under the [LGPL](https://www.gnu.org/licenses/lgpl-3.0.en.html), and the file gives the details. Taylor Hanayik of the FSL group provided pseudo code for functions with little available documentation. The PolygoniseCube function comes from Cory Bloyd's public domain [Marching Cubes example](http://paulbourke.net/geometry/polygonise/) program. Jesper Andersson wrote the bwlabel.cpp file and explicitly allowed it to be shared under the BSD 2-Clause license. Jouni Malinen wrote the [high performance](https://github.com/gaspardpetit/base64) base64.cpp, distributed under the BSD license. [Sven Forstmann](https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification) wrote the mesh simplification, distributed under the MIT license. Chris Rorden ported it from C++ to C. Cameron Hart wrote [radixsort.c](https://github.com/bitshifter/radixsort) (2014) under the zlib license.
 
-The `-romeo` phase-unwrapping command (`src/romeo.c`) is a C port of [ROMEO.jl](https://github.com/korbinian90/ROMEO.jl) and the [MriResearchTools.jl](https://github.com/korbinian90/MriResearchTools.jl) helpers its command-line app uses, by Korbinian Eckstein, Barbara Dymerska and Simon Robinson, together with the 2π range reduction from the Julia standard library. All are distributed under the MIT license; the upstream copyright and permission notices are preserved verbatim in `src/romeo.LICENSE`. Unlike the GPL module below, `-romeo` is compiled in **by default**, so a standard niimath binary contains this MIT-licensed component — MIT is compatible with the 2-Clause BSD License, so the binary as a whole remains BSD-2-Clause. `ROMEO=0 make` (or `-DENABLE_ROMEO=OFF`) omits it.
+The `-romeo` phase-unwrapping command (`src/romeo.c`) is a C port of [ROMEO.jl](https://github.com/korbinian90/ROMEO.jl) and the [MriResearchTools.jl](https://github.com/korbinian90/MriResearchTools.jl) helpers its command-line app uses, by Korbinian Eckstein, Barbara Dymerska and Simon Robinson, together with the 2π range reduction from the Julia standard library. All are distributed under the MIT license. The upstream copyright and permission notices are preserved verbatim in `src/romeo.LICENSE`. Unlike the GPL module below, `-romeo` is compiled in **by default**, so a standard niimath binary contains this MIT-licensed component. MIT is compatible with the 2-Clause BSD License, so the binary as a whole remains BSD-2-Clause. `ROMEO=0 make` (or `-DENABLE_ROMEO=OFF`) omits it.
 
-The `--medic` and `-unwarp` commands (`src/medic.c`) are original BSD-2-Clause code by the niimath authors: a clean-room emulation of the MEDIC method published by Van et al. (*Imaging Neuroscience* 4, 2026, [doi:10.1162/IMAG.a.1262](https://doi.org/10.1162/IMAG.a.1262)), developed from the paper and from black-box measurement of the reference tool's public executables. No reference implementation, test, build product or debug symbol was read, and no code from it is included; the measurements that fix each convention are recorded in the `medic_bench` repository. Phase unwrapping is performed by the MIT-licensed `-romeo` port described above, so `--medic` requires it (`ROMEO=0` implies `MEDIC=0`); `MEDIC=0 make` or `-DENABLE_MEDIC=OFF` omits MEDIC alone.
+The `--medic` and `-unwarp` commands (`src/medic.c`) are original BSD-2-Clause code by the niimath authors. They are a clean-room emulation of the MEDIC method published by Van et al. (*Imaging Neuroscience* 4, 2026, [doi:10.1162/IMAG.a.1262](https://doi.org/10.1162/IMAG.a.1262)), developed from the paper and from black-box measurement of the reference tool's public executables. No reference implementation, test, build product or debug symbol was read, and no code from it is included. The measurements that fix each convention are recorded in the `medic_bench` repository. Phase unwrapping uses the MIT-licensed `-romeo` port described above, so `--medic` requires it (`ROMEO=0` implies `MEDIC=0`). `MEDIC=0 make` or `-DENABLE_MEDIC=OFF` omits MEDIC alone.
 
-The `-moco` and `-stc` commands (`src/moco.c`, `src/stc.c`) are original BSD-2-Clause code by the niimath authors. Both emulate a published AFNI method whose reference implementation is **GPL-2** — `3dvolreg`, `mri_3dalign`, `thd_rot3d` and `thd_shear3d` for `-moco`; `3dTshift` and its FFT for `-stc`. Those sources were **not** read, translated or paraphrased; they served only as black-box oracles. The clean-room specification is the published method (Cox & Jesmanowicz 1999 for `-moco`; AFNI's published `3dTshift -help` and `-verbose` output for `-stc`) together with measured inputs and outputs, recorded in the `moco_bench` repository (`test/moco_reference_manifest.md` and `test/stc_reference_manifest.md`). The FFT in `stc.c` is original niimath code — a batched Stockham autosort kernel; no FFT implementation was read or adapted. A binary containing these commands remains BSD-2-Clause.
+The `-moco` and `-stc` commands (`src/moco.c`, `src/stc.c`) are original BSD-2-Clause code by the niimath authors. Both emulate a published AFNI method whose reference implementation is **GPL-2**: `3dvolreg`, `mri_3dalign`, `thd_rot3d` and `thd_shear3d` for `-moco`, and `3dTshift` and its FFT for `-stc`. Those sources were **not** read, translated or paraphrased. They served only as black-box oracles. The clean-room specification is the published method (Cox & Jesmanowicz 1999 for `-moco`; AFNI's published `3dTshift -help` and `-verbose` output for `-stc`) together with measured inputs and outputs, recorded in the `moco_bench` repository (`test/moco_reference_manifest.md` and `test/stc_reference_manifest.md`). The FFT in `stc.c` is original niimath code, a batched Stockham autosort kernel. No FFT implementation was read or adapted. A binary containing these commands remains BSD-2-Clause.
 
-The optional `-spm_coreg` and `-spm_deface` commands link the separate GPL-2 `spm_coreg` module (the [niimath_gpl](https://github.com/rordenlab/niimath_gpl) submodule), enabled only when built with `make GPL=1` (`-DHAVE_GPL`). A binary built that way is a combined work licensed under the GNU GPL-2; the default build (without the module) remains BSD-2-Clause. The version string reported by `niimath` ends in ` GPL` or ` BSD` to indicate which applies.
+The optional `-spm_coreg` and `-spm_deface` commands link the separate GPL-2 `spm_coreg` module (the [niimath_gpl](https://github.com/rordenlab/niimath_gpl) submodule). They are enabled only when built with `make GPL=1` (`-DHAVE_GPL`). A binary built that way is a combined work licensed under the GNU GPL-2. The default build, without the module, remains BSD-2-Clause. The version string reported by `niimath` ends in ` GPL` or ` BSD` to show which applies.
 
 ## Links
 
-  - [imbibe](https://github.com/jonclayden/imbibe) is a R wrapper for niimath, allowing the performance of tuned code with the convenience of a scripting language.
-  - [3dcalc](https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dcalc.html) is AFNI's tool for image arithmetic.
-  - [c3d](https://sourceforge.net/p/c3d/git/ci/master/tree/doc/c3d.md) provides mathematical functions and format conversion for medical images.
-  - [fslmaths](https://fsl.fmrib.ox.ac.uk/fslcourse/lectures/practicals/intro3/index.html) is the inspiration for niimath.
+- [imbibe](https://github.com/jonclayden/imbibe) is an R wrapper for niimath. It gives the performance of tuned code with the convenience of a scripting language.
+- [3dcalc](https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dcalc.html) is AFNI's tool for image arithmetic.
+- [c3d](https://sourceforge.net/p/c3d/git/ci/master/tree/doc/c3d.md) provides mathematical functions and format conversion for medical images.
+- [fslmaths](https://fsl.fmrib.ox.ac.uk/fslcourse/lectures/practicals/intro3/index.html) is the inspiration for niimath.
 
 ## Citation
 
-  - Rorden C, Webster M, Drake C,  Jenkinson M, Clayden JD, Li N, Hanayik T ([2024](https://apertureneuro.org/article/94384-niimath-and-fslmaths-replication-as-a-method-to-enhance-popular-neuroimaging-tools)) niimath and fslmaths: replication as a method to enhance popular neuroimaging tools. Aperture Neuro.4. doi:10.52294/001c.94384
+- Rorden C, Webster M, Drake C, Jenkinson M, Clayden JD, Li N, Hanayik T ([2024](https://apertureneuro.org/article/94384-niimath-and-fslmaths-replication-as-a-method-to-enhance-popular-neuroimaging-tools)) niimath and fslmaths: replication as a method to enhance popular neuroimaging tools. Aperture Neuro. 4. doi:10.52294/001c.94384

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ sudo chown $(whoami) ./niimath/src/niimath
 
 ## JavaScript and WebAssembly
 
-niimath compiles to WebAssembly, so you can use it in web pages and Node.js projects. See the [live demo](https://niivue.github.io/niivue-niimath/), which links to source code and instructions, and the [@niivue/niimath README](https://github.com/rordenlab/niimath/blob/master/js/README.md). The rest of this README describes the `niimath` command-line program.
+niimath compiles to WebAssembly, so you can use it in web pages. The `@niivue/niimath` package runs the processing in a Web Worker and is meant for the browser, not for Node.js. See the [live demo](https://niivue.github.io/niivue-niimath/), which links to source code and instructions, and the [@niivue/niimath README](https://github.com/rordenlab/niimath/blob/master/js/README.md). The rest of this README describes the `niimath` command-line program.
 
 ## Usage
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,17 +1,47 @@
 # Releasing niimath
 
-Procedure for cutting a release. Kept out of `AGENTS.md` because it is needed a few times a year, not every session — but the traps below are real and were each paid for once.
+This is the procedure for cutting a release. It is kept out of `AGENTS.md` because it is needed a few times a year, not every session. Each guard below exists because its failure was paid for once.
 
-### Release / deploy checks (catch wheel failures BEFORE tagging)
-`release.yml` (push to `master` and `v*.*.*` tags) builds Python wheels with **cibuildwheel** across five OS/arch runners and runs **`.github/scripts/release_smoke.py` as the per-wheel `CIBW_TEST_COMMAND`** (`pyproject.toml`) — inside EVERY target Python from `requires-python` (currently `>=3.7`) up. Distinct failure surface from the rest of CI, which only runs the smoke on the runner's modern `python3`:
-- **`release_smoke.py` MUST run on the package-minimum Python.** A stdlib symbol newer than the minimum (e.g. `math.prod` 3.8+, `str.removeprefix` 3.9+, `math.isqrt` 3.8+) passes ordinary CI but fails only on the OLDEST wheel at release. Keep it stdlib-only AND minimum-Python-clean: use the local **`_prod()`** helper instead of `math.prod`, avoid other post-minimum stdlib features. `from __future__ import annotations` keeps type hints deferred, so PEP 585/604 annotations are fine.
-- **`release-checks.yml` is the fast pre-deploy guard.** On every `pull_request` (blocks BEFORE merge to `master` triggers a release) and on the release push/tag it runs `vermin --target=<min> --violations` on the smoke, reading `<min>` from `pyproject.toml`. Do NOT pass `--eval-annotations` (the `__future__` import already makes annotations non-evaluated).
-- `make_fixtures.py`/`reg_quality.py` run only on the runner's modern `python3` (never inside a wheel) — NOT minimum-Python-constrained; only `release_smoke.py` is.
-- Reproduce the wheel-test locally: `pipx run cibuildwheel --only <id>` or `python3.7 .github/scripts/release_smoke.py <binary>`.
-**Three release outputs, three mechanisms** (independent — the npm version is NOT the CLI `kMTHdate`):
-- **Python wheels → PyPI:** `release.yml` (cibuildwheel, `deploy-pypi`) on a `v*.*.*` tag / master push. PyPI rejects a duplicate version, so do NOT re-push an existing tag expecting a re-upload — cut a new version.
-- **Standalone CLI binaries → GitHub Release assets** (`niimath_{win,lnx,macos}.zip`): `release-binaries.yml`, using the built-in **`GITHUB_TOKEN`**; AppVeyor only builds/tests. macOS binary is a universal (x86_64+arm64) lipo with static zstd (from source, self-contained) and no OpenMP (single-arch libomp can't link into a universal binary). **Lesson: never gate a release on a rotating PAT — prefer `GITHUB_TOKEN`.** To (re)attach binaries to an existing release WITHOUT re-tagging (and without re-triggering the one-shot PyPI upload), run `release-binaries.yml` via `workflow_dispatch` with the tag as input.
-- **npm package `@niivue/niimath` (BSD-only) → npmjs.** MANUAL publish from `js/` (no CI publish). `neurolabusc` and `thanayik` have `read-write` (via the `@niivue` org); **2FA is required to publish** (E403 otherwise). Steps, from a clean `master`: (1) bump `js/package.json` `version`; (2) `cd js && bun run build` — `dist/` is gitignored, so a fresh build is REQUIRED before publish; (3) `npm pack --dry-run --json` to verify the tarball is BSD-only (no GPL/test artifacts — `tests/pack.test.ts` asserts this); (4) `npm publish --access public`. **2FA handling:** a configured **passkey** makes bare `npm publish` succeed interactively; otherwise `--otp=<code>`, or an npm Automation / "bypass 2FA" token in `~/.npmrc`. Keep the committed `js/package.json` version matching what was published.
+## The three release outputs
 
-### macOS universal release (zstd)
-The AppVeyor macOS job builds a universal binary from separate x86_64 + arm64 slices via `lipo`. Homebrew ships only the runner's native arch of libzstd, so the job builds a **universal static `libzstd.a` from source** (`-arch x86_64 -arch arm64`) and points both slices at it via `PKG_CONFIG_PATH` (also self-contained, no runtime `libzstd.dylib`). `src/CMakeLists.txt` resolves the pkg-config result to a full library path. The universal build also passes `-DOPENMP_XCODE=OFF` — hence `OPENMP_XCODE` must remain a consumed, override-able option.
+Each output has its own mechanism, and the three are independent. The npm version is NOT the CLI `kMTHdate`.
+
+| Output | Mechanism | Trigger |
+|---|---|---|
+| Python wheels to PyPI | `release.yml` (cibuildwheel, `deploy-pypi`) | push to `master`, or a `v*.*.*` tag |
+| Standalone CLI binaries as GitHub Release assets (`niimath_{win,lnx,macos}.zip`) | `release-binaries.yml`, with the built-in `GITHUB_TOKEN` | a `v*.*.*` tag, or `workflow_dispatch` with the tag as input |
+| npm package `@niivue/niimath` (BSD-only) on npmjs | manual `npm publish` from `js/` | by hand; there is no CI publish |
+
+AppVeyor only builds and tests. It publishes nothing.
+
+## Procedure
+
+### Before you tag
+
+1. Check that `release-checks.yml` passed on the pull request. It runs `vermin --target=<min> --violations` on `.github/scripts/release_smoke.py`, reading `<min>` from `pyproject.toml`. It runs on every `pull_request`, so it blocks before a merge to `master` triggers a release, and it runs again on the release push or tag.
+2. If you changed `release_smoke.py`, keep it stdlib-only and clean for the package-minimum Python (currently `>=3.7`). See the guards below.
+3. To reproduce the wheel test locally, run `pipx run cibuildwheel --only <id>` or `python3.7 .github/scripts/release_smoke.py <binary>`.
+
+### Python wheels and CLI binaries
+
+1. Push the `v*.*.*` tag. `release.yml` builds the wheels and uploads them to PyPI. `release-binaries.yml` attaches the CLI binaries to the GitHub release.
+2. PyPI rejects a duplicate version. Do NOT re-push an existing tag and expect a new upload. Cut a new version instead.
+3. To attach binaries to an existing release again WITHOUT re-tagging, and without re-triggering the one-shot PyPI upload, run `release-binaries.yml` via `workflow_dispatch` with the tag as input.
+
+### npm package
+
+Publish by hand from a clean `master`. `neurolabusc` and `thanayik` have `read-write` access through the `@niivue` org. **2FA is required to publish** (E403 otherwise).
+
+1. Bump `version` in `js/package.json`.
+2. Run `cd js && bun run build`. `dist/` is gitignored, so a fresh build is REQUIRED before you publish.
+3. Run `npm pack --dry-run --json` and check that the tarball is BSD-only, with no GPL or test artifacts. `tests/pack.test.ts` asserts this.
+4. Run `npm publish --access public`. With a configured **passkey**, bare `npm publish` succeeds interactively. Otherwise pass `--otp=<code>`, or put an npm Automation or "bypass 2FA" token in `~/.npmrc`.
+5. Keep the committed `js/package.json` version equal to the published version.
+
+## Guards and why they exist
+
+- **`release_smoke.py` MUST run on the package-minimum Python.** `release.yml` builds wheels with cibuildwheel across five OS/arch runners and runs `release_smoke.py` as the per-wheel `CIBW_TEST_COMMAND` (`pyproject.toml`), inside EVERY target Python from `requires-python` up. This is a different failure surface from the rest of CI, which runs the smoke test only on the runner's modern `python3`. A stdlib symbol newer than the minimum (for example `math.prod` 3.8+, `str.removeprefix` 3.9+, `math.isqrt` 3.8+) passes ordinary CI but fails only on the OLDEST wheel at release. Use the local `_prod()` helper instead of `math.prod`, and avoid other post-minimum stdlib features. `from __future__ import annotations` keeps type hints deferred, so PEP 585/604 annotations are fine.
+- **`release-checks.yml` is the fast pre-deploy guard.** Do NOT pass `--eval-annotations` to vermin. The `__future__` import already makes annotations non-evaluated.
+- **Only `release_smoke.py` is minimum-Python-constrained.** `make_fixtures.py` and `reg_quality.py` run only on the runner's modern `python3`, never inside a wheel.
+- **Never gate a release on a rotating PAT.** Prefer the auto-provisioned `GITHUB_TOKEN`, as `release-binaries.yml` does.
+- **The macOS binary is a universal build with static zstd and no OpenMP.** The AppVeyor macOS job builds separate x86_64 and arm64 slices and joins them with `lipo`. Homebrew ships only the runner's native arch of libzstd, so the job builds a **universal static `libzstd.a` from source** (`-arch x86_64 -arch arm64`) and points both slices at it via `PKG_CONFIG_PATH`. The binary is self-contained, with no runtime `libzstd.dylib`. `src/CMakeLists.txt` resolves the pkg-config result to a full library path. The universal build passes `-DOPENMP_XCODE=OFF`, because a single-arch libomp cannot link into a universal binary, so `OPENMP_XCODE` must remain a consumed, override-able option.

--- a/js/README.md
+++ b/js/README.md
@@ -1,184 +1,125 @@
 # @niivue/niimath
 
-`@niivue/niimath` is a JavaScript + WASM library for performing mathemetical operations on NIFTI files. This library is intended to be **used in the browser**, not in a Node.js environment.
+`@niivue/niimath` is a JavaScript and WASM library for mathematical operations on NIfTI files. It is intended for use **in the browser**, not in Node.js.
 
-> All image processing operations are performed using the WASM build of [niimath](https://github.com/rordenlab/niimath), making it much faster than a pure JavaScript implementation. The image processing takes place in a separate worker thread, so it won't block the main thread in your application.
+All image processing runs in the WASM build of [niimath](https://github.com/rordenlab/niimath), which is much faster than a pure JavaScript implementation. The processing runs in a separate worker thread, so it does not block the main thread of your application.
+
+## Installation
+
+```bash
+npm install @niivue/niimath # or bun install @niivue/niimath
+```
+
+### Install a local build
+
+Build the library, pack it, and install the package in your application:
+
+```bash
+# from the niimath root directory
+cd js
+bun run build
+npm pack   # creates a .tgz file in the current directory
+npm install /path/to/niivue-niimath.tgz
+```
 
 ## Usage
 
-The `@niivue/niimath` JavaScript library offers an object oriented API for working with the `niimath` CLI. Since `niimath` is a CLI tool, the API implemented in `@niivue/niimath` is just a wrapper around the CLI options and arguments. 
+The library offers an object-oriented API over the `niimath` CLI. Because `niimath` is a command-line tool, the API is a wrapper around the CLI options and arguments.
 
-### Example: volumes
+### Process a volume
 
-For example, the [difference of gaussian](https://www.biorxiv.org/content/biorxiv/early/2022/09/17/2022.09.14.507937.full.pdf) command `niimath input.nii -dog 2 3.2 output.nii` can be executed using the following `@niivue/niimath` JavaScript code:
+The [difference of Gaussians](https://www.biorxiv.org/content/biorxiv/early/2022/09/17/2022.09.14.507937.full.pdf) command `niimath input.nii -dog 2 3.2 output.nii` becomes:
 
 ```javascript
 import { Niimath } from '@niivue/niimath';
 
 const niimath = new Niimath();
-// call the init() method to load the wasm before processing images
+// call init() to load the WASM before you process images
 await niimath.init();
 
-// 1. selectedFile is a browser File object
-// 2. note the use of the final run() method to execute the command. 
-// 3. note the use of await. The run method returns a promise that resolves to the output file if the command is successful.
+// selectedFile is a browser File object.
+// run() executes the command. It returns a promise that resolves to the output file when the command succeeds.
 const outFile = await niimath.image(selectedFile).dog(2, 3.2).run();
 ```
 
-### Registration & defacing
+### Register and deface
 
-The default (BSD-2-Clause) build includes the affine registration and defacing operations `-allineate` and `-deface` (adapted from AFNI 3dAllineate, public domain). These take other browser `File` objects as arguments:
+The default (BSD-2-Clause) build includes the affine registration and defacing operations `-allineate` and `-deface`, adapted from AFNI 3dAllineate (public domain). They take other browser `File` objects as arguments:
 
 ```javascript
 import { Niimath } from '@niivue/niimath';
 const niimath = new Niimath();
 await niimath.init();
 
-// affine-register `selectedFile` onto a base volume
+// affine-register selectedFile onto a base volume
 const registered = await niimath.image(selectedFile).allineate(baseFile).run();
 
-// deface using a template + mask pair
+// deface with a template and mask pair
 const defaced = await niimath.image(selectedFile).deface(templateFile, maskFile).run();
 ```
 
-`allineate(base, opts?, weight?)` accepts an optional third `File`: a graded weight in the base's space (dims and world frame must match `base`). Values are normalized to `[0, 1]`; zero excludes a voxel and larger values contribute more. Both registration engines honor it (the fast engine at its finest stage). Keep the outer head attenuated but nonzero so the whole-head boundary still anchors scale.
+`allineate(base, opts?, weight?)` accepts an optional third `File`: a graded weight in the base's space. Its dimensions and world frame must match `base`. Values are normalized to `[0, 1]`. Zero excludes a voxel, and larger values contribute more. Both registration engines honor the weight (the fast engine at its finest stage). Keep the outer head attenuated but nonzero, so the whole-head boundary still anchors the scale.
 
 ```javascript
-// register `selectedFile` onto `baseFile`, focusing the fit with a graded whole-head weight
+// register selectedFile onto baseFile, with a graded whole-head weight
 const registered = await niimath.image(selectedFile).allineate(baseFile, [], weightFile).run();
 ```
 
-**Worker lifecycle.** `await niimath.init()` once before processing; it spawns a single persistent Web Worker. `init()` returns a promise that rejects if the worker fails to load or instantiate (e.g. the WASM cannot be fetched). **Single-flight:** one `.run()` is in flight per instance at a time — a second overlapping `run()` (or a `run()` before `init()` has resolved) rejects immediately rather than interleaving, so serialize calls (await the previous `run()`) or use a separate instance per concurrent stream. Call `niimath.dispose()` to terminate the worker and release its WASM heap; it is idempotent and rejects any in-flight `init()`/`run()`. A worker crash during a `run()` rejects that run and invalidates the worker — a subsequent `image(...).run()` rejects with "Worker not initialized" until you `init()` again.
+### Use an image as an operand
 
-Two more operations take a `File` operand: `resliceNN(refFile)` reslices the current image onto another image's grid (nearest-neighbour), and `mulImage(imgFile)` multiplies the current image by another image (the generated `mul` only takes a scalar). These let you, e.g., reslice a brain mask onto a native grid and apply it:
+Two more operations take a `File` operand. `resliceNN(refFile)` reslices the current image onto another image's grid with nearest-neighbor interpolation. `mulImage(imgFile)` multiplies the current image by another image (the generated `mul` takes only a scalar). For example, to reslice a brain mask onto a native grid and apply it:
 
 ```javascript
-// reslice `maskFile` (conformed space) onto `nativeFile`'s grid, binarize, save
+// reslice maskFile (conformed space) onto nativeFile's grid, binarize, save
 const maskBlob = await niimath.image(maskFile).resliceNN(nativeFile).bin().run();
-// run() returns a Blob; wrap it in a File so it can be re-fed as an operand
+// run() returns a Blob; wrap it in a File so it can be used as an operand
 const nativeMask = new File([maskBlob], 'nativeMask.nii.gz');
 // keep only the masked region of the native image (now on the same grid)
 const brain = await niimath.image(nativeFile).mulImage(nativeMask).run();
 ```
 
-### SPM coregistration (`-spm_coreg`, `-spm_deface`)
+### Create a mesh
 
-The published `@niivue/niimath` package is **BSD-2-Clause only** and no longer ships the optional GPL-2 SPM coregistration WASM module — the permissively licensed `-allineate`/`-deface` engine supersedes it. The `-spm_coreg`/`-spm_deface` C sources remain in the [`niimath_gpl`](https://github.com/rordenlab/niimath_gpl) submodule and can still be built from source for local/historical use (`GPL=1 make`, or `bun run makeWasmGpl` to produce a GPL WASM), but they are not part of the npm package or its exports.
-
-### Example: meshes
-
-The `@niivue/niimath` library also supports the `-mesh` options available in the `niimath` CLI. However, the JavaScript API is slightly different from the volume processing due to the use of the `-mesh` suboptions. 
+The library supports the `-mesh` options of the `niimath` CLI. The JavaScript API differs slightly from volume processing, because `-mesh` has sub-options. Pass them as an object whose keys are the CLI sub-option letters: `i` (isosurface), `a` (atlas file), `b` (fill bubbles), `l` (only largest), `o` (original marching cubes), `q` (quality), `s` (post smooth), `r` (reduce fraction) and `v` (verbose). See the `-mesh` reference in the [niimath README](https://github.com/rordenlab/niimath#-mesh-opts-output).
 
 ```javascript
 import { Niimath } from '@niivue/niimath';
 const niimath = new Niimath();
 await niimath.init();
-const outName = 'out.mz3'; // outname must be a mesh format!
+const outName = 'out.mz3'; // the output name must use a mesh format
 const outMesh = await niimath.image(selectedFile)
   .mesh({
     i: 'm', // 'd'ark, 'm'edium, 'b'right or numeric (e.g. 128) isosurface
     b: 1, // fill bubbles
   })
   .run(outName);
-/*
-Here's the help from the niimath CLI program
-The mesh option has multiple sub-options:
- -mesh                    : meshify requires 'd'ark, 'm'edium, 'b'right or numeric isosurface ('niimath bet -mesh -i d mesh.gii')
-        -i <isovalue>            : 'd'ark, 'm'edium, 'b'right or numeric isosurface
-        -a <atlasFile>           : roi based atlas to mesh
-        -b <fillBubbles>         : fill bubbles
-        -l <onlyLargest>         : only largest
-        -o <originalMC>          : original marching cubes
-        -q <quality>             : quality
-        -s <postSmooth>          : post smooth
-        -r <reduceFraction>      : reduce fraction
-        -v <verbose>             : verbose
-*/
 ```
 
-## Installation
+## Worker lifecycle
 
-To install `@niivue/niimath` in your project, run the following command:
+- Call `await niimath.init()` once before you process images. It spawns one persistent Web Worker. The promise rejects if the worker fails to load or instantiate, for example when the WASM cannot be fetched.
+- One `.run()` is in flight per instance at a time. A second overlapping `run()`, or a `run()` before `init()` has resolved, rejects immediately instead of interleaving. Serialize calls (await the previous `run()`), or use a separate instance for each concurrent stream.
+- `niimath.dispose()` terminates the worker and releases its WASM heap. It is idempotent, and it rejects any in-flight `init()` or `run()`.
+- A worker crash during a `run()` rejects that run and invalidates the worker. A later `image(...).run()` rejects with "Worker not initialized" until you call `init()` again.
 
-```bash
-npm install @niivue/niimath # or bun install @niivue/niimath
-```
+## SPM coregistration
 
-### To install a local build of the library
-
-Fist, `cd` into the `js` directory of the `niimath` repository.
-
-```bash
-# from niimath root directory
-cd js
-```
-
-To install a local build of the library, run the following command:
-
-```bash
-bun run build
-```
-
-Then, install the library using the following command:
-
-```bash
-npm pack # will create a .tgz file in the root directory
-```
-
-Then, install the `@niivue/niimath` library in your application locally using the following command:
-
-```bash
-npm install /path/to/niivue-niimath.tgz
-```
+The published `@niivue/niimath` package is **BSD-2-Clause only**. It no longer ships the optional GPL-2 SPM coregistration WASM module, because the permissively licensed `-allineate` and `-deface` engine supersedes it. The `-spm_coreg` and `-spm_deface` C sources remain in the [`niimath_gpl`](https://github.com/rordenlab/niimath_gpl) submodule. You can still build them from source for local or historical use (`GPL=1 make`, or `bun run makeWasmGpl` to produce a GPL WASM), but they are not part of the npm package or its exports.
 
 ## Development
 
-Install [Bun](https://bun.com/docs/installation)
-
-First `cd` into the `js` directory of the `niimath` repository.
+Install [Bun](https://bun.com/docs/installation). Then, from the `js` directory of the `niimath` repository:
 
 ```bash
-# from niimath root directory
 cd js
+bun install      # install the dependencies
+bun run build    # build the library
+bun run test     # run the tests
+bun run dev      # start the development server
 ```
 
-To install the dependencies, run the following command:
+`src/niimathOperators.json` and `src/types.ts` are **generated** from the niimath CLI help text and are not checked into git. `bun run build` regenerates them in its `prebuild` step (`parseHelpText` + `generateTypes`). On a fresh clone, run `bun run prebuild` (or `bun run parseHelpText && bun run generateTypes`) once before you use your editor or `tsc`. Otherwise the imports in `src/index.ts` appear missing.
 
-```bash
-bun install
-```
+The tests in `tests/` load the built WASM module from `dist/` directly, through the in-memory filesystem and without a browser Worker, so run `bun run build` first. The package is BSD-only. The historical GPL binding and test are kept under `gpl-historical/` and are not part of the default suite.
 
-To build the library, run the following command
-
-```bash
-bun run build
-```
-
-> **Note:** `src/niimathOperators.json` and `src/types.ts` are **generated** from the
-> niimath CLI help text and are not checked into git. `bun run build` regenerates them
-> via its `prebuild` step (`parseHelpText` + `generateTypes`). On a fresh clone, run
-> `bun run prebuild` (or `bun run parseHelpText && bun run generateTypes`) once before
-> using your editor / `tsc`, otherwise the imports in `src/index.ts` will appear missing.
-
-To run the tests, run the following command:
-
-```bash
-bun run test
-```
-
-The tests in `tests/` load the built WASM module from `dist/` directly (via the
-in-memory filesystem, no browser Worker), so run `bun run build` first. The package
-is BSD-only; the historical GPL binding/test is kept under `gpl-historical/` and is
-not part of the default suite.
-
-### Development server with Hot Module Reloading
-
-To start the development server with hot module reloading:
-
-```bash
-bun run dev
-```
-
-This will start a development server at `http://localhost:3000` with automatic page reloading when source files change.
-
-
+`bun run dev` starts a development server at `http://localhost:3000` with automatic page reloading when source files change.

--- a/js/src/wasi/README.md
+++ b/js/src/wasi/README.md
@@ -1,29 +1,22 @@
 # WASI-C niimath backend
 
-A lean, zlib-free, single-threaded WASI reactor of niimath's **computational BSD** feature set
-(core math, multi-image ops, allineate/deface, dtifit, QC, conform, butterworth). It is the
-experimental WASI-C backend; the shipped default backend remains the Emscripten build
-(`../niimath.js`/`.wasm`).
+A lean, zlib-free, single-threaded WASI reactor of niimath's **computational BSD** feature set: core math, multi-image operations, allineate/deface, dtifit, QC, conform and butterworth. It is the experimental WASI-C backend. The shipped default backend remains the Emscripten build (`../niimath.js` and `../niimath.wasm`).
 
-## What it is (and isn't)
+## What it is and is not
 
-- **Is:** the whole scoped compute engine compiled with `zig cc -target wasm32-wasi
-  -mexec-model=reactor` (Zig bundles wasi-libc — no wasi-sdk install needed). File I/O flows
-  through real wasi-libc stdio, serviced by a small host-side in-memory VFS. NIfTI gzip is done
-  host-side (`CompressionStream`/`node:zlib`), so the module only sees raw `.nii` bytes.
-- **Isn't:** a drop-in replacement yet. **Bitmap (`-bitmap`) and mesh (`-mesh`) are not compiled**
-  — they fail clearly (nonzero exit), never silently no-op. No GPL, zstd, or OpenMP.
+- **Is:** the whole scoped compute engine compiled with `zig cc -target wasm32-wasi -mexec-model=reactor`. Zig bundles wasi-libc, so no wasi-sdk install is needed. File I/O flows through real wasi-libc stdio, serviced by a small host-side in-memory VFS. NIfTI gzip is done host-side (`CompressionStream` or `node:zlib`), so the module sees only raw `.nii` bytes.
+- **Is not:** a drop-in replacement yet. **Bitmap (`-bitmap`) and mesh (`-mesh`) are not compiled.** They fail clearly with a nonzero exit and never silently do nothing. There is no GPL, zstd or OpenMP.
 
 ## Files
 
-| file | role |
+| File | Role |
 |---|---|
-| `../../../src/wasi_shim.c` | reactor entry (`nii_run`) — the only C added; no algorithm changes |
-| `WasiVfs.ts` | narrow host-side in-memory VFS (flat relative namespace, quota, stdout/stderr capture) |
-| `WasiImports.ts` | the 15 frozen WASI Preview-1 imports over the VFS; `proc_exit` → `WasiExit` |
-| `WasiRunner.ts` | reactor lifecycle, argv marshaling, instance recycling, `runFiles`/`runFilesGz` |
-| `gzip.ts` | host-side magic-byte gzip (CompressionStream, falls back to `node:zlib` in Bun) |
-| `featureParity.test.ts`, `compression.test.ts` | Bun conformance, lifecycle, quota, and gzip tests |
+| `../../../src/wasi_shim.c` | Reactor entry (`nii_run`). The only C added; no algorithm changes. |
+| `WasiVfs.ts` | Narrow host-side in-memory VFS: flat relative namespace, quota, stdout/stderr capture. |
+| `WasiImports.ts` | The 15 frozen WASI Preview-1 imports over the VFS. `proc_exit` throws `WasiExit`. |
+| `WasiRunner.ts` | Reactor lifecycle, argv marshaling, instance recycling, `runFiles` and `runFilesGz`. |
+| `gzip.ts` | Host-side magic-byte gzip (CompressionStream, with a fallback to `node:zlib` in Bun). |
+| `featureParity.test.ts`, `compression.test.ts` | Bun conformance, lifecycle, quota and gzip tests. |
 
 ## Build
 
@@ -37,9 +30,7 @@ bun run wasiNodeSmoke                 # plain-Node stream/gzip/quota smoke
 bun run wasiChromium                  # optional real-browser correctness/agreement check
 ```
 
-`wasm-wasi` verifies the toolchain (Zig ≥ 0.16), builds the reactor `-O3 -flto -ffast-math
---strip-all`, and fails if the WASI import surface grows beyond
-[`import-manifest.json`](./import-manifest.json).
+`wasm-wasi` verifies the toolchain (Zig ≥ 0.16), builds the reactor with `-O3 -flto -ffast-math --strip-all`, and fails if the WASI import surface grows beyond [`import-manifest.json`](./import-manifest.json).
 
 ## Use
 
@@ -63,23 +54,14 @@ const g = await runner.runFilesGz({
 });
 ```
 
-`create()` calls `_initialize` once. A normal run reuses the instance after `reset()`; a
-`proc_exit` (error path) recreates it automatically. Multi-output commands (dtifit → 11 files)
-list every output name in `outputs`. One runner is single-flight: await a run before calling another
-run, `reset()`, or `addFile()`, and use one runner per concurrent job. Returned file buffers are
-detached copies and may be mutated by the caller. `runFilesGz()` clears its raw staging state before
-compression/return; retain its returned buffers rather than expecting `readFile()` to expose them.
+`create()` calls `_initialize` once. A normal run reuses the instance after `reset()`. A `proc_exit` (the error path) recreates the instance automatically. A multi-output command (dtifit writes 11 files) must list every output name in `outputs`. One runner is single-flight: await a run before you call another run, `reset()` or `addFile()`, and use one runner per concurrent job. Returned file buffers are detached copies, and the caller may mutate them. `runFilesGz()` clears its raw staging state before compression and return, so keep its returned buffers instead of expecting `readFile()` to expose them.
 
 ## Lifecycle contract
 
-1. `_initialize` exactly once per instance.
-2. Normal `nii_run` return → reuse after `reset()` (clears the VFS).
-3. `proc_exit` → `WasiExit` thrown, exit code captured, instance discarded and recreated (C
-   cleanup was skipped, so linear memory / libc state is untrusted).
+1. `_initialize` runs exactly once per instance.
+2. A normal `nii_run` return permits reuse after `reset()`, which clears the VFS.
+3. A `proc_exit` throws `WasiExit`. The exit code is captured, and the instance is discarded and recreated, because the C cleanup was skipped and the linear memory and libc state are untrusted.
 
 ## Status
 
-Functionally complete and verified: feature parity + payload/header conformance vs the native
-binary pass (`bun run test:wasi`). It is a correct, portable, glue-free backend kept for
-audit/portability. Performance evidence is intentionally deferred until the current source is
-committed; the benchmark lives in `niimath_tests/wasm_benchmark` and is not a release-quality claim.
+Functionally complete and verified: feature parity and payload/header conformance against the native binary pass (`bun run test:wasi`). It is a correct, portable, glue-free backend kept for audit and portability. Performance evidence is deferred until the current source is committed. The benchmark lives in `niimath_tests/wasm_benchmark` and is not a release-quality claim.

--- a/library/README.md
+++ b/library/README.md
@@ -1,36 +1,38 @@
+# Streaming NIfTI images through niimath
+
 ## About
 
-`niimath` is a high-performance command-line tool for manipulating NIfTI images. Because `niimath` is so fast, the main bottleneck in many workflows is disk I/O. To enable efficient workflows, niimath supports reading from and writing to standard input/output streams using the special filename `-`. It is important to note that both the input and output must be single-file NIfTI-1 images (e.g. `img.nii`). Compressed files (e.g. `img.nii.gz`) must be decompressed prior to using the memory stream input.
+`niimath` is a high-performance command-line tool for NIfTI images. Because `niimath` is so fast, disk I/O is the main bottleneck in many workflows. To avoid it, niimath can read from standard input and write to standard output. Use the special filename `-` for either stream. Both the input and the output must be single-file NIfTI-1 images (for example `img.nii`). Decompress compressed files (for example `img.nii.gz`) before you pipe them in.
 
-This streaming capability is especially useful for chaining tools together without writing intermediate results to disk. For example:
-
-```bash
-niimath - add 1 -     # read from stdin, add 1, write to stdout
-```
-
-Note that only one image can be piped at a time. For example:
+Streaming lets you chain tools without writing intermediate results to disk:
 
 ```bash
-niimath - add img.nii -   # input image is piped; second image is read from disk
+niimath - -add 1 -     # read from stdin, add 1, write to stdout
 ```
 
-## Demo Scripts
+Only one image can be piped at a time. A second image is read from disk:
 
-This folder contains minimal Python scripts demonstrating how to use these features. These assume niimath is available in your system path. Note that some scripts use nibabel while others demonstrate direct interaction if you do not wish to include nibabel as a dependency.
+```bash
+niimath - -add img.nii -   # the input image is piped; the second image is read from disk
+```
+
+## Demo scripts
+
+This folder contains minimal Python scripts that show these features. They assume that `niimath` is on your system path. Some scripts use nibabel. Others show direct interaction, for when you do not want nibabel as a dependency.
 
 ```bash
 # Generate a synthetic NIfTI volume with a 3D pattern
 python generate_borg.py
 
-# Use niimath to process a NIfTI file and return the result via stdout (no disk writes)
+# Process a NIfTI file and return the result via stdout (no disk writes)
 python write_stdout.py
 
-# Pipe a NIfTI image to niimath via stdin, output saved to disk
+# Pipe a NIfTI image to niimath via stdin, and save the output to disk
 python read_stdin.py
 
 # Pipe a NIfTI image to niimath and capture the output via stdout, fully in memory
 python read_write_stream.py
 
-# Use nibabel to_bytes() and from_bytes() to call niimath using pipes
+# Use nibabel to_bytes() and from_bytes() to call niimath through pipes
 python nibabel_niimath.py
 ```


### PR DESCRIPTION
## Summary

Rewrites the user-facing documentation with the Diataxis framework and plain English (short sentences, active voice, one paragraph per line). No code or CLI help strings change.

- `README.md`: typed sections. About, Compatibility with fslmaths and Performance are explanation. Installation, Compilation, Usage, meshes and bitmaps are how-to guides. A new "Operations not in fslmaths" section is a complete reference: a table for the simple operations, then one subsection per complex command with a fixed pattern (arguments, options, outputs, constraints, citation).
- `js/README.md`: installation before usage; the worker lifecycle in its own section; the mesh example links to the README reference instead of pasting the help text.
- `js/src/wasi/README.md`: hard-wrapped paragraphs unwrapped to one line each (repository style rule); files as a table.
- `library/README.md`: stdin/stdout syntax corrected.
- `RELEASING.md`: a table of the three release outputs, a numbered procedure, and the guards with their reasons. No trap dropped.

## Fact corrections

- `AFNI_COMPRESSOR=PIGZ` is described as parallel gzip compression only. Threads come from `-p` or `OMP_NUM_THREADS`.
- The library example `niimath - add 1 -` was missing the dash on `-add`.
- `-edt` and `-sedt` are named Euclidean distance transform. The help text says "Euler"; the code is the Felzenszwalb parabola method.
- `-bitmap` with one dash. The parser accepts only `-bitmap`; the README said `--bitmap`.
- The known-differences list is renumbered (it skipped item 5).
- Added to the reference from the help text: `-bitmap -c2h -close -comply -conform -dilate -edginess -erode -gz -h2c -hollow -p -ras -reslice -reslice_nn -reslice_mask -scale01 -sedt` and `--compare <thresh> <ref>`.

## Heading renames (anchor churn)

- "Identical Versus Equivalent Results" is now under "Compatibility with fslmaths".
- "Superior Performance" is now "Performance".
- "Converting voxelwise images to a triangulated mesh" is now "Creating meshes".
- "JavaScript/WebAssembly" and the trailing "WebAssembly" are merged into "JavaScript and WebAssembly".
- Installation, Compilation, Usage, License, Links and Citation are unchanged.

## Notes for review

- `README.md` is also the PyPI long description. Links to other files use absolute GitHub URLs. In-page anchor links work on GitHub but may not resolve on PyPI.
- American spelling in prose. CLI strings inside code spans keep their original spelling.
- Left alone on purpose: the C help strings (FSL text copied verbatim by permission, and `js/scripts/parseNiimathHelp.ts` generates the JS types from them), `AGENTS.md` and `CLAUDE.md` (agent-facing), and `noncompliant.md` (a code archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3tVJ2crLT4yRSrLtjt3YT
